### PR TITLE
fix: bigint/integer incompatibility caused by switching to consistent bigint formats

### DIFF
--- a/src/bot/commandsSlash/config-xp/bonustime.ts
+++ b/src/bot/commandsSlash/config-xp/bonustime.ts
@@ -13,7 +13,7 @@ registerSubCommand({
     const cachedGuild = await getGuildModel(i.guild);
 
     const bonusUntilDate = Math.floor(Date.now() / 1000 + i.options.getInteger('time', true) * 60);
-    await cachedGuild.upsert({ bonusUntilDate });
+    await cachedGuild.upsert({ bonusUntilDate: bonusUntilDate.toString() });
     await i.reply({ content: `Bonus time has started! It will end <t:${bonusUntilDate}:R>.` });
   },
   async executeAutocomplete(interaction) {

--- a/src/bot/commandsSlash/memberinfo.ts
+++ b/src/bot/commandsSlash/memberinfo.ts
@@ -55,16 +55,17 @@ registerSlashCommand({
         ? targetMemberInfo.joinedAt
         : Math.ceil(targetMemberInfo.joinedAt / 1000);
 
+    console.warn('Tgt User', myTargetUser);
+
+    const patreonTierUntilDate = new Date(parseInt(myTargetUser.patreonTierUntilDate) * 1000);
+
     const patreonText =
-      myTargetUser.patreonTierUntilDate > Date.now() / 1000 && myTargetUser.patreonTier > 0
+      patreonTierUntilDate.getTime() > Date.now() / 1000 && myTargetUser.patreonTier > 0
         ? stripIndent`
           Active Tier: ${myTargetUser.patreonTier} (${fct.getPatreonTierName(
             myTargetUser.patreonTier,
           )})
-          Valid until: ${time(myTargetUser.patreonTierUntilDate, 'D')}, ${time(
-            myTargetUser.patreonTierUntilDate,
-            'R',
-          )}`
+          Valid until: ${time(patreonTierUntilDate, 'D')}, ${time(patreonTierUntilDate, 'R')}`
         : 'No active Tier';
 
     const embed = new EmbedBuilder()

--- a/src/bot/commandsSlash/rank.ts
+++ b/src/bot/commandsSlash/rank.ts
@@ -12,6 +12,7 @@ import {
   type InteractionEditReplyOptions,
   type ActionRowData,
   type MessageActionRowComponentData,
+  time,
 } from 'discord.js';
 
 import cooldownUtil from '../util/cooldownUtil.js';
@@ -292,12 +293,10 @@ async function generateRankCard(
     .setColor('#4fd6c8')
     .setThumbnail(state.targetUser.avatarURL());
 
-  if (myGuild.bonusUntilDate > Date.now() / 1000) {
-    embed.setDescription(
-      `**!! Bonus XP Active !!** (${Math.round(
-        (((myGuild.bonusUntilDate - Date.now() / 1000) / 60 / 60) * 10) / 10,
-      )}h left) \n`,
-    );
+  const bonusUntil = new Date(parseInt(myGuild.bonusUntilDate) * 1000);
+
+  if (bonusUntil.getTime() > Date.now()) {
+    embed.setDescription(`**!! Bonus XP ends ${time(bonusUntil, 'R')} !!**\n`);
   }
 
   const infoStrings = [

--- a/src/bot/commandsSlash/serverinfo.ts
+++ b/src/bot/commandsSlash/serverinfo.ts
@@ -205,7 +205,7 @@ const info: WindowFn = async ({ interaction, cachedGuild }) => {
   });
 
   let bonusTimeString = '';
-  if (cachedGuild.db.bonusUntilDate > Date.now() / 1000) {
+  if (parseInt(cachedGuild.db.bonusUntilDate) > Date.now() / 1000) {
     bonusTimeString = `**!! Bonus XP Active !!** (ends <t:${cachedGuild.db.bonusUntilDate}:R>)
     ${cachedGuild.db.bonusPerTextMessage * cachedGuild.db.xpPerBonus} Bonus XP per textmessage
     ${cachedGuild.db.bonusPerVoiceMinute * cachedGuild.db.xpPerBonus} Bonus XP per voiceminute

--- a/src/bot/commandsSlash/upvote.ts
+++ b/src/bot/commandsSlash/upvote.ts
@@ -84,7 +84,7 @@ registerSlashCommand({
       );
     } else {
       await interaction.reply(oneLine`You have successfully voted for ${targetMember}. 
-      Upvote the bot on top.gg or subscribe [on Patreon](https://www.patreon.com/rapha01) to increase your voting power!`);
+      Upvote the bot on top.gg or subscribe [on Patreon](<https://www.patreon.com/rapha01>) to increase your voting power!`);
     }
   },
 });

--- a/src/bot/contextMenus/Upvote.ts
+++ b/src/bot/contextMenus/Upvote.ts
@@ -80,7 +80,7 @@ registerContextMenu({
       );
     } else {
       await interaction.reply(oneLine`You have successfully voted for ${targetMember}. 
-        Upvote the bot on top.gg or subscribe on https://www.patreon.com/rapha01 to increase your voting power!`);
+        Upvote the bot on top.gg or subscribe [on Patreon](<https://www.patreon.com/rapha01>) to increase your voting power!`);
     }
   },
 });

--- a/src/bot/events/guildDelete.ts
+++ b/src/bot/events/guildDelete.ts
@@ -4,6 +4,6 @@ import { getGuildModel, guildCache } from '../models/guild/guildModel.js';
 
 registerEvent(Events.GuildDelete, async function (guild) {
   const cachedGuild = await getGuildModel(guild);
-  await cachedGuild.upsert({ leftAtDate: Date.now() / 1000 });
+  await cachedGuild.upsert({ leftAtDate: (Date.now() / 1000).toString() });
   guildCache.delete(guild);
 });

--- a/src/bot/models/guild/guildModel.ts
+++ b/src/bot/models/guild/guildModel.ts
@@ -111,7 +111,7 @@ async function buildCache(guild: Guild): Promise<GuildModel> {
       .insertInto('guild')
       .values({
         guildId: guild.id,
-        joinedAtDate: Math.floor(guild.members.me!.joinedAt!.getTime() / 1000),
+        joinedAtDate: Math.floor(guild.members.me!.joinedAt!.getTime() / 1000).toString(),
         addDate: Math.floor(Date.now() / 1000).toString(),
       })
       .executeTakeFirstOrThrow();

--- a/src/bot/statFlushCache.ts
+++ b/src/bot/statFlushCache.ts
@@ -31,7 +31,7 @@ export async function addTextMessage(
 
   await addTotalXp(member, count * cachedGuild.db.xpPerTextMessage);
 
-  if (cachedGuild.db.bonusUntilDate > Date.now() / 1000)
+  if (parseInt(cachedGuild.db.bonusUntilDate) > Date.now() / 1000)
     await addBonus(member, count * cachedGuild.db.bonusPerTextMessage);
 }
 
@@ -59,7 +59,7 @@ export async function addVoiceMinute(
 
   await addTotalXp(member, count * cachedGuild.db.xpPerVoiceMinute);
 
-  if (cachedGuild.db.bonusUntilDate > Date.now() / 1000)
+  if (parseInt(cachedGuild.db.bonusUntilDate) > Date.now() / 1000)
     await addBonus(member, count * cachedGuild.db.bonusPerVoiceMinute);
 }
 
@@ -81,7 +81,7 @@ export const addInvite = async (member: GuildMember, count: number) => {
 
   await addTotalXp(member, count * cachedGuild.db.xpPerInvite);
 
-  if (cachedGuild.db.bonusUntilDate > Date.now() / 1000)
+  if (parseInt(cachedGuild.db.bonusUntilDate) > Date.now() / 1000)
     await addBonus(member, count * cachedGuild.db.bonusPerInvite);
 };
 
@@ -103,7 +103,7 @@ export const addVote = async (member: GuildMember, count: number) => {
 
   await addTotalXp(member, count * cachedGuild.db.xpPerVote);
 
-  if (cachedGuild.db.bonusUntilDate > Date.now() / 1000)
+  if (parseInt(cachedGuild.db.bonusUntilDate) > Date.now() / 1000)
     await addBonus(member, count * cachedGuild.db.bonusPerVote);
 };
 

--- a/src/bot/util/askForPremium.ts
+++ b/src/bot/util/askForPremium.ts
@@ -24,9 +24,9 @@ export default async function (interaction: ChatInputCommandInteraction<'cached'
   const myUser = await userModel.fetch();
 
   const now = Math.floor(Date.now() / 1000);
-  if (now - myUser.lastAskForPremiumDate < askForPremiumCdUser) return;
+  if (now - parseInt(myUser.lastAskForPremiumDate) < askForPremiumCdUser) return;
 
-  await userModel.upsert({ lastAskForPremiumDate: now });
+  await userModel.upsert({ lastAskForPremiumDate: now.toString() });
   cachedGuild.cache.lastAskForPremiumDate = new Date();
 
   await sendAskForPremiumEmbed(interaction);

--- a/src/bot/util/askForPremium.ts
+++ b/src/bot/util/askForPremium.ts
@@ -1,9 +1,10 @@
 import { getUserModel } from '../models/userModel.js';
 import fct from '../../util/fct.js';
 import { getWaitTime } from './cooldownUtil.js';
-import { ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
+import { ButtonStyle, ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
 import { oneLine } from 'common-tags';
 import { getGuildModel } from 'bot/models/guild/guildModel.js';
+import { ComponentType } from 'discord.js';
 
 const isDev = process.env.NODE_ENV !== 'production';
 
@@ -43,8 +44,24 @@ async function sendAskForPremiumEmbed(interaction: ChatInputCommandInteraction<'
     value: oneLine`${interaction.user}, please consider helping us by becoming a Patron. 
       The bot is mostly free! Activating Premium for you or your server can unlock some new 
       features and gives you quality of life upgrades, like reduced cooldowns on commands. 
-      Simply go to https://patreon.com/rapha01/ select your preferred tier and become a Patron. **Thank you!**`,
+      Simply [select your preferred tier and become a Patron!](<https://patreon.com/rapha01>). **Thank you!**`,
   });
 
-  await interaction.followUp({ embeds: [e], ephemeral: true });
+  await interaction.followUp({
+    embeds: [e],
+    components: [
+      {
+        type: ComponentType.ActionRow,
+        components: [
+          {
+            type: ComponentType.Button,
+            style: ButtonStyle.Link,
+            url: 'https://www.patreon.com/rapha01',
+            label: 'Support us on Patreon!',
+          },
+        ],
+      },
+    ],
+    ephemeral: true,
+  });
 }

--- a/src/models/types/kysely/shard.ts
+++ b/src/models/types/kysely/shard.ts
@@ -48,7 +48,7 @@ export interface GuildSchema {
   bonusPerVoiceMinute: Generated<number>;
   bonusPerVote: Generated<number>;
   bonusPerInvite: Generated<number>;
-  bonusUntilDate: Generated<number>;
+  bonusUntilDate: Generated<string>; // bigint
   reactionVote: Generated<number>;
   allowMutedXp: Generated<number>;
   allowDeafenedXp: Generated<number>;
@@ -73,12 +73,12 @@ export interface GuildSchema {
   voiceChanneleaveMessage: Generated<string>;
   roleAssignMessage: Generated<string>;
   roleDeassignMessage: Generated<string>;
-  lastCommandDate: Generated<number>;
-  lastTokenBurnDate: Generated<number>;
+  lastCommandDate: Generated<string>; // bigint
+  lastTokenBurnDate: Generated<string>; // bigint
   resetDay: Generated<number>;
   resetHour: Generated<number>;
-  joinedAtDate: Generated<number>;
-  leftAtDate: Generated<number>;
+  joinedAtDate: Generated<string>; // bigint
+  leftAtDate: Generated<string>; // bigint
   addDate: Generated<string>;
   isBanned: Generated<number>;
 }
@@ -159,12 +159,12 @@ export interface UserSchema {
   tokensGifted: Generated<number>;
   voteMultiplier: Generated<number>;
   voteMultiplierUntil: Generated<number>;
-  lastAskForPremiumDate: Generated<number>;
+  lastAskForPremiumDate: Generated<string>; // bigint
   addDate: Generated<string>;
   isBanned: Generated<number>;
   patreonTier: Generated<number>;
-  patreonTierUntilDate: Generated<number>;
-  lastTopggUpvoteDate: Generated<number>;
+  patreonTierUntilDate: Generated<string>;
+  lastTopggUpvoteDate: Generated<string>;
 }
 export type User = Selectable<UserSchema>;
 export type NewUser = Insertable<UserSchema>;

--- a/src/util/fct.ts
+++ b/src/util/fct.ts
@@ -62,12 +62,12 @@ export const getPatreonTiers = async (interaction: Interaction<'cached'>) => {
   const myOwnerUser = await ownerModel.fetch();
 
   let userTier;
-  if (Date.now() / 1000 <= myUser.patreonTierUntilDate) {
+  if (Date.now() / 1000 <= parseInt(myUser.patreonTierUntilDate)) {
     userTier = myUser.patreonTier;
   } else userTier = 0;
 
   let ownerTier;
-  if (Date.now() / 1000 <= myOwnerUser.patreonTierUntilDate) {
+  if (Date.now() / 1000 <= parseInt(myOwnerUser.patreonTierUntilDate)) {
     ownerTier = myOwnerUser.patreonTier;
   } else ownerTier = 0;
 
@@ -75,15 +75,15 @@ export const getPatreonTiers = async (interaction: Interaction<'cached'>) => {
 };
 
 export const getVoteMultiplier = (myUser: {
-  lastTopggUpvoteDate: number;
-  patreonTierUntilDate: number;
+  lastTopggUpvoteDate: string;
+  patreonTierUntilDate: string;
   patreonTier: number;
 }) => {
   let multiplier = 1;
 
-  if (myUser.lastTopggUpvoteDate + 259200 > Date.now() / 1000) multiplier = 2;
+  if (parseInt(myUser.lastTopggUpvoteDate) + 259200 > Date.now() / 1000) multiplier = 2;
 
-  if (myUser.patreonTierUntilDate > Date.now() / 1000 && myUser.patreonTier > 0) {
+  if (parseInt(myUser.patreonTierUntilDate) > Date.now() / 1000 && myUser.patreonTier > 0) {
     if (myUser.patreonTier == 1) multiplier = 2;
     else if (myUser.patreonTier == 2) multiplier = 3;
     else if (myUser.patreonTier == 3) multiplier = 4;


### PR DESCRIPTION
with `promise-mysql`, bigints of a certain size were displayed as Numbers, while others were Strings. The switch caused all `bigint` fields to be stored as Strings in JS, requiring typing and code updates.

Also removes Opengraph embeds for Patreon due to unfortunate naming in the example leaderboard that was displayed as part of the embed.