### PR TITLE
feat: add warnings to some commands

### DIFF
--- a/src/bot/commandsSlash/bonus/member.ts
+++ b/src/bot/commandsSlash/bonus/member.ts
@@ -7,6 +7,13 @@ registerSubCommand({
   execute: async (interaction) => {
     const member = interaction.options.getMember('member')!;
 
+    if (member.user.bot) {
+      return await interaction.reply({
+        content: 'You cannot add bonus XP to bots.',
+        ephemeral: true,
+      });
+    }
+
     if (
       !interaction.channel ||
       !interaction.member.permissionsIn(interaction.channel).has(PermissionFlagsBits.ManageGuild)

--- a/src/bot/commandsSlash/bonus/role.ts
+++ b/src/bot/commandsSlash/bonus/role.ts
@@ -209,7 +209,7 @@ async function getApplicableMembers(
       }
 
       for (const member of members.values()) {
-        if (member.roles.cache.has(roleId)) {
+        if (member.roles.cache.has(roleId) && !member.user.bot) {
           applicableMembers.add(member.id);
           console.debug(`Added ${member.id}`);
         }

--- a/src/bot/commandsSlash/config-role/menu.ts
+++ b/src/bot/commandsSlash/config-role/menu.ts
@@ -13,7 +13,7 @@ import {
 
 import guildRoleModel from '../../models/guild/guildRoleModel.js';
 import nameUtil from '../../util/nameUtil.js';
-import { parseRole } from '../../util/parser.js';
+import { ParserResponseStatus, parseRole } from '../../util/parser.js';
 import { registerComponent, registerModal, registerSubCommand } from 'bot/util/commandLoader.js';
 import type { GuildRoleSchema } from 'models/types/shard.js';
 
@@ -72,9 +72,13 @@ registerSubCommand({
       });
     }
 
-    const resolvedRole = await parseRole(interaction);
-
-    if (!resolvedRole) {
+    const resolvedRole = parseRole(interaction);
+    if (resolvedRole.status === ParserResponseStatus.ConflictingInputs) {
+      return await interaction.reply({
+        content: `You have specified both a role and an ID, but they don't match.\nDid you mean: "/config-role menu role:${interaction.options.get('role')!.value}"?`,
+        ephemeral: true,
+      });
+    } else if (resolvedRole.status === ParserResponseStatus.NoInput) {
       return await interaction.reply({
         content: "You need to specify either a role or a role's ID!",
         ephemeral: true,

--- a/src/bot/commandsSlash/reset/channel.ts
+++ b/src/bot/commandsSlash/reset/channel.ts
@@ -9,7 +9,7 @@ import {
 } from 'discord.js';
 import resetModel from '../../models/resetModel.js';
 import nameUtil from '../../util/nameUtil.js';
-import { parseChannel } from '../../util/parser.js';
+import { ParserResponseStatus, parseChannel } from '../../util/parser.js';
 import { ComponentKey, registerSubCommand } from 'bot/util/commandLoader.js';
 
 registerSubCommand({
@@ -25,9 +25,13 @@ registerSubCommand({
       });
     }
 
-    const resolvedChannel = await parseChannel(interaction);
-
-    if (!resolvedChannel) {
+    const resolvedChannel = parseChannel(interaction);
+    if (resolvedChannel.status === ParserResponseStatus.ConflictingInputs) {
+      return await interaction.reply({
+        content: `You have specified both a channel and an ID, but they don't match.\nDid you mean: "/reset channel channel:${interaction.options.get('channel')!.value}"?`,
+        ephemeral: true,
+      });
+    } else if (resolvedChannel.status === ParserResponseStatus.NoInput) {
       return await interaction.reply({
         content: "You need to specify either a channel or a channel's ID!",
         ephemeral: true,


### PR DESCRIPTION
The bot will now warn when both `id` and `member` (or `channel`/`role`) arguments are passed and suggest that only one is used. It will prioritise the non-`id` one.