### PR TITLE
Add /update-roles command

### DIFF
--- a/apps/bot/locales/en-US/command-content.json
+++ b/apps/bot/locales/en-US/command-content.json
@@ -81,7 +81,7 @@
     "everyone": "You cannot make @everyone a level role.",
     "manageRoles": "Please ensure the bot has the permission to manage roles.",
     "error1": "Using an assignLevel higher than or equal to a deassignLevel will not work: the role gets removed as soon as it gets added!\nDid you mean: **assign-level:{{deassignLevel}} deassign-level:{{assignLevel}}**?",
-    "maxRoles": "There is a maximum of 3 roles that can be assigned or deassigned from each level. Please remove some first.",
+    "maxRoles": "There is a maximum of 3 roles that can be assigned or deassigned from each level. Level {{level}} is full - please remove some first.",
     "roleAdded": "Assign/Deassignments for this role",
     "assignlevel": "Assignment Level",
     "deassignlevel": "Deassignment Level",

--- a/apps/bot/locales/en-US/command-content.json
+++ b/apps/bot/locales/en-US/command-content.json
@@ -26,6 +26,7 @@
     "text": "text",
     "voice": "voice",
     "totalXP": "Total XP: {{xp}} (#{{rank}})",
+    "zeroXp": "Total XP: 0",
     "nextLevel": "Next Level: {{percent}}%",
     "stats": "Stats",
     "topChannels": "Top Channels"

--- a/apps/bot/locales/en-US/command-descriptions.json
+++ b/apps/bot/locales/en-US/command-descriptions.json
@@ -94,6 +94,7 @@
   "config-xp.xp-per-role.vote": "The amount of XP gained per upvote",
   "config-xp.xp-per-role.invite": "The amount of XP gained per member invited to the server",
   "bonus.role.role": "Change the bonus XP of all members with a given role.",
+  "update-roles": "Resync all activity roles for every user in the server",
   "blacklist.user": "Blacklist a user from the bot.",
   "blacklist.user.user": "The user to blacklist",
   "blacklist.guild": "Blacklist a guild from the bot.",

--- a/apps/bot/src/bot/commands/config-server/cooldown.ts
+++ b/apps/bot/src/bot/commands/config-server/cooldown.ts
@@ -31,7 +31,7 @@ export default command({
       let dura = Temporal.Duration.from({ seconds });
       // balances `dura` up until "x days"
       // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration#duration_balancing
-      dura = dura.round('days');
+      dura = dura.round({ largestUnit: 'days' });
 
       return new DurationFormat([interaction.locale, 'en-US'], { style: 'long' }).format(dura);
     }

--- a/apps/bot/src/bot/commands/update-roles.ts
+++ b/apps/bot/src/bot/commands/update-roles.ts
@@ -1,0 +1,341 @@
+import { command } from '#bot/commands.js';
+import { Temporal } from 'temporal-polyfill';
+import { DurationFormat } from '@formatjs/intl-durationformat';
+import { shards } from '#models/shardDb/shardDb.js';
+import { getGuildModel } from '#bot/models/guild/guildModel.js';
+import { getLevelProgression, sleep } from '#util/fct.js';
+import { checkRoleAssignment } from '#bot/levelManager.js';
+import {
+  type AnyThreadChannel,
+  ButtonStyle,
+  type Collection,
+  ComponentType,
+  type GuildMember,
+  type GuildTextBasedChannel,
+  MessageFlags,
+  type Webhook,
+} from 'discord.js';
+import { container } from '#bot/util/component.js';
+import { component, ComponentKey } from '#bot/util/registry/component.js';
+import { requireUser } from '#bot/util/predicates.js';
+import { renderProgressBar } from '#bot/models/resetModel.js';
+import { Time } from '@sapphire/duration';
+
+export const activeUpdates: Map<
+  string,
+  { startedAt: Date; endedAt: Date | null; members: number }
+> = new Map();
+export const cancelQueue = new Set();
+
+export default command({
+  name: 'update-roles',
+  async execute({ interaction, t }) {
+    await interaction.deferReply();
+
+    const lastUpdate = activeUpdates.get(interaction.guild.id);
+    if (
+      lastUpdate &&
+      (!lastUpdate.endedAt || new Date().getTime() - lastUpdate.endedAt.getTime() < Time.Hour * 4)
+    ) {
+      await interaction.followUp({
+        components: [
+          container([
+            {
+              type: ComponentType.TextDisplay,
+              content: lastUpdate.endedAt
+                ? `## Sorry!\nYour latest update only ended <t:${Math.floor(lastUpdate.endedAt.getTime() / 1000)}:R>. You can run another update <t:${Math.floor((lastUpdate.endedAt.getTime() + Time.Hour * 4) / 1000)}:R>.`
+                : '## Sorry!\nYour latest update is still running. Please wait for it to complete.',
+            },
+          ]),
+        ],
+        flags: [MessageFlags.IsComponentsV2],
+      });
+      return;
+    }
+
+    // clean up state
+    cancelQueue.delete(interaction.guild.id);
+    activeUpdates.delete(interaction.guild.id);
+
+    const members = await interaction.guild.members.fetch();
+
+    // 1.2 seconds per member
+    const duration = fmtDuration(interaction.locale, Math.ceil(members.size * 1.2));
+
+    const cachedGuild = await getGuildModel(interaction.guild);
+
+    const content = `## Mass Role Update\nUpdating roles for **${members.size}** members. While roles are processing, please avoid updating server settings.\nIn ideal conditions, this will take **${duration}**.`;
+    const warnings = [];
+
+    if (!cachedGuild.db.takeAwayAssignedRolesOnLevelDown) {
+      warnings.push({
+        title: 'Take Away Assigned Roles is disabled',
+        description:
+          'Take Away Assigned Roles on Level Down is disabled. While this setting is disabled, members with a role above their current level will not lose it. Use `/config-server set` to change this behaviour.',
+      });
+    }
+
+    let canCreateHook = false;
+    if (!interaction.appPermissions.has('ManageWebhooks', true)) {
+      warnings.push({
+        title: 'Manage Webhooks permissions are disabled',
+        description:
+          'I do not have `Manage Webhooks` permissions in this channel. Because of this, I can only update you on the progress of the update for 15 minutes.',
+      });
+    } else if (interaction.channel?.isThread()) {
+      warnings.push({
+        title: 'Cannot create webhook in Thread channel',
+        description:
+          'I cannot create webhooks in this channel. Because of this, I can only update you on the progress of the update for 15 minutes. To fix this, run the command again from a text channel.',
+      });
+    } else {
+      canCreateHook = true;
+    }
+
+    await interaction.followUp({
+      components: [
+        container([
+          {
+            type: ComponentType.TextDisplay,
+            content,
+          },
+          ...warnings.map((w) => ({
+            type: ComponentType.TextDisplay,
+            content: `### :warning: ${w.title}\n${w.description}`,
+          })),
+          {
+            type: ComponentType.ActionRow,
+            components: [
+              {
+                type: ComponentType.Button,
+                style: ButtonStyle.Primary,
+                label: 'Start Role Update',
+                customId: run.instanceId({
+                  data: { members, createHook: canCreateHook },
+                  predicate: requireUser(interaction.user),
+                }),
+              },
+            ],
+          },
+        ]),
+      ],
+      flags: [MessageFlags.IsComponentsV2],
+    });
+  },
+});
+
+function fmtDuration(locale: string, seconds: number): string {
+  let dura = Temporal.Duration.from({ seconds });
+  // balances `dura` up until "x days"
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration#duration_balancing
+  const smallestUnit = seconds > 60 * 3 ? 'minutes' : 'seconds';
+  dura = dura.round({ smallestUnit, largestUnit: 'days' });
+
+  return new DurationFormat([locale, 'en-US'], { style: 'long' }).format(dura);
+}
+
+function isNotThreadChannel(
+  channel: GuildTextBasedChannel,
+): channel is Exclude<GuildTextBasedChannel, AnyThreadChannel> {
+  return !channel.isThread();
+}
+
+const run = component<{ members: Collection<string, GuildMember>; createHook: boolean }>({
+  type: ComponentType.Button,
+  async callback({ interaction, data, t }) {
+    await interaction.update({
+      components: [
+        container([
+          {
+            type: ComponentType.TextDisplay,
+            content: `## Mass Role Update\nUpdating roles for **${data.members.size}** members. While roles are processing, please avoid updating server settings.\nIn ideal conditions, this will take **${fmtDuration(interaction.locale, Math.ceil(data.members.size * 1.2))}**.`,
+          },
+          {
+            type: ComponentType.ActionRow,
+            components: [
+              {
+                type: ComponentType.Button,
+                style: ButtonStyle.Primary,
+                label: 'Start Role Update',
+                customId: ComponentKey.Throw,
+                disabled: true,
+              },
+            ],
+          },
+        ]),
+      ],
+    });
+    const cachedGuild = await getGuildModel(interaction.guild);
+
+    let canUpdate = true;
+    let updateHook: Webhook | null = null;
+    let updateHookMessage: string | null = null;
+    if (data.createHook) {
+      const channel = interaction.channel;
+      if (!channel?.isTextBased() || !isNotThreadChannel(channel)) {
+        throw new Error('should have been checked in the command above');
+      }
+      updateHook = await channel.createWebhook({
+        name: 'Role Updates',
+        avatar: interaction.client.user.avatarURL({ size: 2048 }),
+      });
+    }
+
+    const memberCount = data.members.size;
+    const { db } = shards.get(cachedGuild.dbHost);
+
+    activeUpdates.set(interaction.guild.id, {
+      startedAt: new Date(),
+      members: memberCount,
+      endedAt: null,
+    });
+
+    function buildComponents(completion: number, disableCancel: boolean) {
+      return [
+        container([
+          {
+            type: ComponentType.TextDisplay,
+            content: `## Role Update\n\n${renderProgressBar(completion)}`,
+          },
+          {
+            type: ComponentType.ActionRow,
+            components: [
+              {
+                type: ComponentType.Button,
+                style: ButtonStyle.Secondary,
+                label: 'Cancel',
+                disabled: disableCancel,
+                customId: cancel.instanceId({ predicate: requireUser(interaction.user) }),
+              },
+            ],
+          },
+        ]),
+      ];
+    }
+
+    if (updateHook) {
+      const msg = await updateHook.send({
+        components: buildComponents(0, false),
+        flags: [MessageFlags.IsComponentsV2],
+      });
+      updateHookMessage = msg.id;
+    } else {
+      await interaction.update({ components: buildComponents(0, false) });
+    }
+
+    for (let i = 0; i <= Math.floor(memberCount / 100); i++) {
+      const memberIds = Array.from({ length: 100 }, (_, n) =>
+        data.members.keyAt(i * 100 + n),
+      ).filter((n) => n !== undefined);
+
+      const res = await db
+        .selectFrom('guildMember')
+        .select(['userId', 'alltime'])
+        .where('guildId', '=', interaction.guild.id)
+        .where('userId', 'in', memberIds)
+        .execute();
+
+      for (const memberId of memberIds) {
+        // before each member is processed, check if we need to cancel
+        if (cancelQueue.has(interaction.guild.id)) {
+          return;
+        }
+
+        const discordMember = data.members.get(memberId);
+        if (!discordMember) {
+          // `memberIds` is based on `data.members`
+          throw new Error();
+        }
+
+        if (discordMember.user.bot) {
+          await sleep(1000); // sleep for 1 second
+          continue;
+        }
+
+        const xp = res.find((i) => i.userId === memberId)?.alltime ?? 0;
+        const level = Math.floor(getLevelProgression(xp, cachedGuild.db.levelFactor));
+
+        // TODO: the whole checkRoleAssignment module needs a refactor
+        await checkRoleAssignment(discordMember, level);
+        await sleep(1000); // sleep for 1 second
+      }
+
+      // To avoid race conditions, check if the job has been cancelled just before editing messages too
+      if (cancelQueue.has(interaction.guild.id)) {
+        return;
+      }
+
+      if (updateHook) {
+        if (!updateHookMessage) {
+          throw new Error();
+        }
+        await updateHook.editMessage(updateHookMessage, {
+          components: buildComponents(((i + 1) * 100) / memberCount, false),
+        });
+      } else if (canUpdate) {
+        await interaction
+          .update({ components: buildComponents(((i + 1) * 100) / memberCount, false) })
+          .catch(() => {
+            // probably ran out of updating time; avoid trying to update again
+            canUpdate = false;
+          });
+      }
+    }
+
+    const thisUpdate = activeUpdates.get(interaction.guild.id);
+    if (thisUpdate) {
+      activeUpdates.set(interaction.guild.id, { ...thisUpdate, endedAt: new Date() });
+    }
+
+    if (updateHook) {
+      if (!updateHookMessage) {
+        throw new Error();
+      }
+      await updateHook.editMessage(updateHookMessage, { components: buildComponents(1, true) });
+    } else if (canUpdate) {
+      await interaction.update({ components: buildComponents(1, true) }).catch(() => {
+        // probably ran out of updating time; avoid trying to update again
+        canUpdate = false;
+      });
+    }
+  },
+});
+
+const cancel = component({
+  type: ComponentType.Button,
+  async callback({ interaction }) {
+    cancelQueue.add(interaction.guild.id);
+    // just in case it isn't removed properly, clean up after 2 hours
+    setTimeout(() => cancelQueue.delete(interaction.guild.id), Time.Hour * 2);
+
+    const thisUpdate = activeUpdates.get(interaction.guild.id);
+    // set endedAt value
+    if (thisUpdate) {
+      activeUpdates.set(interaction.guild.id, { ...thisUpdate, endedAt: new Date() });
+    }
+
+    const message = {
+      components: [
+        container([
+          {
+            type: ComponentType.TextDisplay,
+            content: '## Role Update\n\n```ansi\n\u001b[1;31mCANCELLED\n```',
+          },
+          {
+            type: ComponentType.ActionRow,
+            components: [
+              {
+                type: ComponentType.Button,
+                style: ButtonStyle.Secondary,
+                label: 'Cancel',
+                disabled: true,
+                customId: ComponentKey.Throw,
+              },
+            ],
+          },
+        ]),
+      ],
+    };
+    await interaction.update(message);
+  },
+});

--- a/apps/bot/src/bot/models/guild/guildRoleModel.ts
+++ b/apps/bot/src/bot/models/guild/guildRoleModel.ts
@@ -131,7 +131,7 @@ export async function fetchRoleAssignmentsByLevel(
     .execute();
 }
 
-export async function fetchRoleAssignmentsByRole(guild: Guild, roleId: string) {
+export async function fetchRoleAssignmentByRole(guild: Guild, roleId: string) {
   const { dbHost } = await getGuildModel(guild);
 
   return await shards
@@ -140,7 +140,7 @@ export async function fetchRoleAssignmentsByRole(guild: Guild, roleId: string) {
     .select(['roleId', 'assignLevel', 'deassignLevel', 'assignMessage', 'deassignMessage'])
     .where('guildId', '=', guild.id)
     .where('roleId', '=', roleId)
-    .execute();
+    .executeTakeFirst();
 }
 
 export async function fetchNoXpRoleIds(guild: Guild) {

--- a/apps/bot/src/bot/models/rankModel.ts
+++ b/apps/bot/src/bot/models/rankModel.ts
@@ -377,7 +377,7 @@ export async function getGuildMemberStatPosition(
     .executeTakeFirstOrThrow();
 
   // If the member_count is either 0 or NULL, return `null`
-  if (typeof member_count === 'number' || member_count < 1) {
+  if (typeof member_count === 'number' || Number.parseInt(member_count.toString()) < 1) {
     return null;
   }
 

--- a/apps/bot/src/bot/util/i18n.ts
+++ b/apps/bot/src/bot/util/i18n.ts
@@ -2,8 +2,8 @@ import i18next, { type CustomTypeOptions } from 'i18next';
 import Backend, { type FsBackendOptions } from 'i18next-fs-backend';
 import { fileURLToPath } from 'node:url';
 
-export const formatListAnd = new Intl.ListFormat('en-US', { style: 'long', type: 'conjunction' })
-  .format;
+export const createConjunctionListFormatter = (locale: string) =>
+  new Intl.ListFormat([locale, 'en-US'], { style: 'long', type: 'conjunction' });
 
 let loaded = false;
 export async function ensureI18nLoaded() {

--- a/apps/bot/src/bot/util/registry/commands.generated.ts
+++ b/apps/bot/src/bot/util/registry/commands.generated.ts
@@ -1,4 +1,4 @@
-/* 🛠️ This file was generated with `activityrank generate` on Fri Feb 21 2025. */
+/* 🛠️ This file was generated with `activityrank generate` on Sun May 11 2025. */
 
 import { Command, type OptionKey, type CommandPredicateConfig } from './command.js';
 import type {
@@ -477,6 +477,15 @@ export function command(options: {
   }) => CommandReturn;
 }): Command;
 export function command(options: {
+  name: 'update-roles';
+  predicate?: CommandPredicateConfig;
+  execute: (args: {
+    interaction: ChatInputCommandInteraction<'cached'>;
+    client: Client;
+    t: TFunction<'command-content'>;
+  }) => CommandReturn;
+}): Command;
+export function command(options: {
   name: 'blacklist user';
   predicate?: CommandPredicateConfig;
   execute: (args: {
@@ -657,6 +666,7 @@ export const COMMAND_META: {
   },
   top: { optionGetters: {}, type: 'base-command' },
   rank: { optionGetters: { member: ['user'] }, type: 'base-command' },
+  'update-roles': { optionGetters: {}, type: 'base-command' },
   'blacklist user': { optionGetters: { user: ['user'] }, type: 'subcommand' },
   'blacklist guild': { optionGetters: { id: ['value'] }, type: 'subcommand' },
   eval: {

--- a/apps/cli/src/util/classes.ts
+++ b/apps/cli/src/util/classes.ts
@@ -164,7 +164,7 @@ export class DiscordCommandManagementCommand extends ConfigurableCommand {
 
     for (const { lang, success, data } of parsedLocalizations) {
       if (!success) {
-        console.warn(`Language "${lang}" is missing a \`command-descriptions.json\` file.`);
+        p.log.warn(`Language "${lang}" is missing a \`command-descriptions.json\` file.`);
         continue;
       }
       localizations.set(lang, data);
@@ -192,7 +192,7 @@ export class DiscordCommandManagementCommand extends ConfigurableCommand {
       const res: Record<string, string> = {};
       for (const [lang, value] of localizations.entries()) {
         if (value?.[key]) {
-          res[lang] = value[key];
+          res[mapLanguageKey(lang)] = value[key];
         } else {
           missingDescriptions.push({ lang, key });
         }
@@ -263,7 +263,7 @@ export class DiscordCommandManagementCommand extends ConfigurableCommand {
 
     if (missingDescriptions.length > 0) {
       for (const desc of missingDescriptions.filter((d) => d.lang !== 'en-US')) {
-        console.warn(`Missing description translation: ${desc.lang}::${desc.key}`);
+        p.log.warn(`Missing description translation: ${desc.lang}::${desc.key}`);
       }
     }
     if (missingDescriptions.some((d) => d.lang === 'en-US')) {
@@ -288,5 +288,16 @@ export class DiscordCommandManagementCommand extends ConfigurableCommand {
     });
 
     this.commands = await this.getDeployableCommands();
+  }
+}
+
+function mapLanguageKey(key: string): string {
+  switch (key) {
+    case 'es':
+      return 'es-ES';
+    case 'pt-PT':
+      return 'pt-BR';
+    default:
+      return key;
   }
 }

--- a/config/commands.json
+++ b/config/commands.json
@@ -492,6 +492,11 @@
     ]
   },
   {
+    "default_member_permissions": "8",
+    "type": 1,
+    "name": "update-roles"
+  },
+  {
     "default_member_permissions": "6",
     "type": 1,
     "deployment": "LOCAL_ONLY",

--- a/config/commands.json
+++ b/config/commands.json
@@ -248,13 +248,13 @@
             "type": 4,
             "name": "assign-level",
             "min_value": 0,
-            "max_value": 500
+            "max_value": 1000
           },
           {
             "type": 4,
             "name": "deassign-level",
             "min_value": 0,
-            "max_value": 500
+            "max_value": 1000
           }
         ]
       },


### PR DESCRIPTION
* Fixes localization deployment issues (`es` should be `es-ES`)
* Fixes errors caused by `outdent` pr #152 
* Improves usability of `/config-role levels`
  * Changed max level from `500` to `1000`
* Added `/update-roles` command
  * Allows an admin to update all members' roles in the server
  * Has a 4-hour cooldown
  * Creates a webhook to provide updates after 15 minutes
  * Progress bar updates every 100 users
  * Allows for cancellation midway through
  * Provides warnings if TAAROLD is disabled
  * <ins>not</ins> localized, because translation progress has been slow. Will localize later once translators are caught up.