### PR TITLE
fix: CI quote type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
-        if: env.APP != "cli"
+        if: env.APP != 'cli'
         with:
           context: .
           file: ./apps/${{ env.APP }}/Dockerfile


### PR DESCRIPTION
GitHub doesn't allow double quotes in string literals: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#literals