### PR TITLE
feat: improve autosend message handling

### DIFF
--- a/apps/bot/locales/en-US/command-content.json
+++ b/apps/bot/locales/en-US/command-content.json
@@ -83,19 +83,19 @@
     "description": "**Adjust the server-wide messages that the bot sends when events are triggered.**\n## Available variables:\n* `<name>`: The username of the relevant user.\n* `<servername>`: The name of the server.\n* `<level>`: The new level of the relevant user.\n* `<mention>`: The @mention of the relevant user.\n* `<rolename>`: The name of the user's new role (on level up/level down).\n* `<rolemention>`: The @mention of the user's new role (on level up/level down).",
     "editAgain": "Did you get something wrong?\nAvailible variables: `<name>`, `<servername>`, `<level>`, `<mention>`, `<rolename>`, `<rolemention>`",
     "serverJoinMessage": "Server Join Message",
-    "serverJoinMessageDescription": "The message to send when a member joins the server",
+    "serverJoinMessageDescription": "The message to send when a member joins the server.",
     "serverJoinMessageNew": "The new Join Message",
     "serverJoinMessageSet": "Set Join Message",
     "levelupMessage": "Levelup Message",
-    "levelupMessageDescription": "The message to send when a member gains a level",
+    "levelupMessageDescription": "The message to send when a member gains a level.",
     "levelupMessageNew": "The new Levelup Message",
     "levelupMessageSet": "Set Levelup Message",
     "roleAssignMessage": "Role Assign Message",
-    "roleAssignMessageDescription": "The message to send when a member gains a role, unless overridden by a role-specific message",
+    "roleAssignMessageDescription": "The message to send when a member gains a role, unless overridden by a role-specific message.",
     "roleAssignMessageNew": "The new Role Assign Message",
     "roleAssignMessageSet": "Set Role Assign Message",
     "roleDeassignMessage": "Role Deassign Message",
-    "roleDeassignMessageDescription": "The message to send when a member loses a role, unless overridden by a role-specific message",
+    "roleDeassignMessageDescription": "The message to send when a member loses a role, unless overridden by a role-specific message.",
     "roleDeassignMessageNew": "The new Role Deassign Message",
     "roleDeassignMessageSet": "Set Role Deassign Message",
     "cleared": "Cleared {{value}}",
@@ -103,7 +103,8 @@
       "enabled": "Enabled",
       "not-enabled": "Disabled",
       "edit": "Edit",
-      "clear": "Clear"
+      "clear": "Clear",
+      "test": "Test"
     }
   },
   "config-role": {

--- a/apps/bot/locales/en-US/command-content.json
+++ b/apps/bot/locales/en-US/command-content.json
@@ -118,8 +118,10 @@
     "noXp": "No XP",
     "noXpDescription": "Prevent XP from being given to any members that have this role.",
     "assignMessage": "Assignment Message",
+    "assignMessageSet": "Set Assignment Message",
     "assignMessageDescription": "Edit the message sent when this role is given to a member. This defaults to the server-wide Assignment Message.",
     "deassignMessage": "Deassignment Message",
+    "deassignMessageSet": "Set Deassignment Message",
     "deassignMessageDescription": "Edit the message sent when this role is removed from a member. This defaults to the server-wide Deassignment Message.",
     "clearMessage": "Clear a message",
     "toClear": "Which message do you want to clear?'",
@@ -127,15 +129,15 @@
     "assignToSend": "The message to send upon assignment",
     "deassignToSend": "The message to send upon deassignment",
     "roleSettings": "Role Settings",
-    "removedAssign": "Removed Assignment Message of role <@&{{roleId}}>.",
-    "removedDeassign": "Removed Deassignment Message of role <@&{{roleId}}>.",
     "addedAssign": "Added Assignment Message for role <@&{{roleId}}>.",
     "addedDeassign": "Added Deassignment Message for <@&{{roleId}}>.",
+    "editAgain": "Did you get something wrong?\nAvailible variables: `<name>`, `<servername>`, `<level>`, `<mention>`, `<rolename>`, `<rolemention>`",
     "button": {
       "enabled": "Enabled",
       "not-enabled": "Disabled",
       "edit": "Edit",
-      "clear": "Clear"
+      "clear": "Clear",
+      "test": "Preview"
     }
   },
   "config-server": {

--- a/apps/bot/locales/en-US/command-content.json
+++ b/apps/bot/locales/en-US/command-content.json
@@ -104,7 +104,7 @@
       "not-enabled": "Disabled",
       "edit": "Edit",
       "clear": "Clear",
-      "test": "Test"
+      "test": "Preview"
     }
   },
   "config-role": {

--- a/apps/bot/src/bot/commands/config-role/menu.ts
+++ b/apps/bot/src/bot/commands/config-role/menu.ts
@@ -1,9 +1,5 @@
 import {
   ButtonStyle,
-  ActionRowBuilder,
-  EmbedBuilder,
-  ModalBuilder,
-  TextInputBuilder,
   TextInputStyle,
   PermissionFlagsBits,
   ComponentType,
@@ -11,6 +7,7 @@ import {
   type ContainerComponentData,
   type BaseMessageOptions,
   MessageFlags,
+  type ModalComponentData,
 } from 'discord.js';
 import { getRoleModel, type RoleModel } from '#bot/models/guild/guildRoleModel.js';
 import { getRoleMention } from '../../util/nameUtil.js';
@@ -22,27 +19,6 @@ import type { TFunction } from 'i18next';
 import invariant from 'tiny-invariant';
 
 type AssignType = 'assignMessage' | 'deassignMessage';
-
-const getModal = (t: TFunction<'command-content'>, role: RoleModel, type: AssignType) =>
-  new ModalBuilder()
-    .setCustomId(messageModal.instanceId({ data: { type, role } }))
-    .setTitle(
-      type === 'assignMessage' ? t('config-role.assignMessage') : t('config-role.deassignMessage'),
-    )
-    .addComponents(
-      new ActionRowBuilder<TextInputBuilder>().addComponents(
-        new TextInputBuilder()
-          .setCustomId('msg-component-1')
-          .setLabel(
-            type === 'assignMessage'
-              ? t('config-role.assignToSend')
-              : t('config-role.deassignToSend'),
-          )
-          .setStyle(TextInputStyle.Paragraph)
-          .setMaxLength(1000)
-          .setRequired(true),
-      ),
-    );
 
 export default command({
   name: 'config-role menu',
@@ -113,8 +89,11 @@ async function renderPage(
       actionrow([
         {
           type: ComponentType.Button,
-          customId: modalButton.instanceId({ data: { role, type: 'assignMessage' }, predicate }),
-          style: ButtonStyle.Secondary,
+          customId: modalButton.instanceId({
+            data: { role, type: 'assignMessage', editOriginal: true },
+            predicate,
+          }),
+          style: ButtonStyle.Primary,
           label: t('config-role.button.edit'),
         },
         {
@@ -127,6 +106,16 @@ async function renderPage(
           disabled: role.db.assignMessage === '',
           label: t('config-role.button.clear'),
         },
+        {
+          type: ComponentType.Button,
+          customId: testMessageButton.instanceId({
+            data: { role, type: 'assignMessage' },
+            predicate,
+          }),
+          style: ButtonStyle.Secondary,
+          disabled: role.db.assignMessage === '',
+          label: t('config-role.button.test'),
+        },
       ]),
       {
         type: ComponentType.TextDisplay,
@@ -135,8 +124,11 @@ async function renderPage(
       actionrow([
         {
           type: ComponentType.Button,
-          customId: modalButton.instanceId({ data: { role, type: 'deassignMessage' }, predicate }),
-          style: ButtonStyle.Secondary,
+          customId: modalButton.instanceId({
+            data: { role, type: 'deassignMessage', editOriginal: true },
+            predicate,
+          }),
+          style: ButtonStyle.Primary,
           label: t('config-role.button.edit'),
         },
         {
@@ -149,6 +141,16 @@ async function renderPage(
           disabled: role.db.deassignMessage === '',
           label: t('config-role.button.clear'),
         },
+        {
+          type: ComponentType.Button,
+          customId: testMessageButton.instanceId({
+            data: { role, type: 'deassignMessage' },
+            predicate,
+          }),
+          style: ButtonStyle.Secondary,
+          disabled: role.db.deassignMessage === '',
+          label: t('config-role.button.test'),
+        },
       ]),
     ],
     { accentColor: 0x01c3d9 },
@@ -157,18 +159,85 @@ async function renderPage(
   return [main];
 }
 
+function getModal(
+  t: TFunction<'command-content'>,
+  role: RoleModel,
+  type: AssignType,
+  editOriginal: boolean,
+): ModalComponentData {
+  return {
+    customId: messageModal.instanceId({ data: { type, role, editOriginal } }),
+    title: t(`config-role.${type}`),
+    components: [
+      actionrow([
+        {
+          customId: 'msg-component-1',
+          label:
+            type === 'assignMessage'
+              ? t('config-role.assignToSend')
+              : t('config-role.deassignToSend'),
+          type: ComponentType.TextInput,
+          style: TextInputStyle.Paragraph,
+          required: true,
+          maxLength: 1000,
+          value: role.db[type],
+        },
+      ]),
+    ],
+  };
+}
+
 const unsetMessageButton = component<{ role: RoleModel; type: AssignType }>({
   type: ComponentType.Button,
   async callback({ interaction, data, t }) {
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferUpdate();
 
     await data.role.upsert({ [data.type]: '' });
 
     await interaction.editReply({
-      content: t(
-        data.type === 'assignMessage' ? 'config-role.removedAssign' : 'config-role.removedDeassign',
-        { roleId: data.role.object.id },
-      ),
+      components: await renderPage(t, data.role.object.id, data.role, interaction),
+    });
+  },
+});
+
+const testMessageButton = component<{ role: RoleModel; type: AssignType }>({
+  type: ComponentType.Button,
+  async callback({ interaction, data, t }) {
+    const value = data.role.db[data.type];
+
+    await interaction.reply({
+      components: [
+        container(
+          [
+            {
+              type: ComponentType.TextDisplay,
+              content: `## ${t(`config-role.${data.type}`)}`,
+            },
+            {
+              type: ComponentType.Section,
+              components: [
+                {
+                  type: ComponentType.TextDisplay,
+                  content: `-# ${t('config-role.editAgain')}`,
+                },
+              ],
+              accessory: {
+                type: ComponentType.Button,
+                customId: modalButton.instanceId({
+                  data: { ...data, editOriginal: false },
+                  predicate: requireUser(interaction.user),
+                }),
+                style: ButtonStyle.Secondary,
+                label: t('config-role.button.edit'),
+              },
+            },
+            { type: ComponentType.Separator, spacing: 2 },
+            { type: ComponentType.TextDisplay, content: value },
+          ],
+          { accentColor: 0x01c3d9 },
+        ),
+      ],
+      flags: [MessageFlags.IsComponentsV2, MessageFlags.Ephemeral],
     });
   },
 });
@@ -192,27 +261,68 @@ const noXpButton = component<{ role: RoleModel }>({
   },
 });
 
-const modalButton = component<{ role: RoleModel; type: AssignType }>({
+const modalButton = component<{ role: RoleModel; type: AssignType; editOriginal: boolean }>({
   type: ComponentType.Button,
   async callback({ interaction, data, t }) {
-    await interaction.showModal(getModal(t, data.role, data.type));
+    await interaction.showModal(getModal(t, data.role, data.type, data.editOriginal));
   },
 });
 
-const messageModal = modal<{ type: AssignType; role: RoleModel }>({
+const messageModal = modal<{ type: AssignType; role: RoleModel; editOriginal: boolean }>({
   async callback({ interaction, data, t }) {
+    await interaction.deferUpdate();
+
     const { role, type } = data;
     const value = interaction.fields.getTextInputValue('msg-component-1');
     await role.upsert({ [type]: value });
 
-    await interaction.deferReply({ ephemeral: true });
-    await interaction.followUp({
-      content: t(
-        type === 'assignMessage' ? 'config-role.addedAssign' : 'config-role.addedDeassign',
-        { roleId: role.object.id },
-      ),
-      embeds: [new EmbedBuilder().setDescription(value).setColor(0x01c3d9)],
-      ephemeral: true,
-    });
+    const response = {
+      components: [
+        container(
+          [
+            {
+              type: ComponentType.TextDisplay,
+              content: `## ${t(`config-role.${data.type}Set`)}`,
+            },
+            {
+              type: ComponentType.Section,
+              components: [
+                {
+                  type: ComponentType.TextDisplay,
+                  content: `-# ${t('config-role.editAgain')}`,
+                },
+              ],
+              accessory: {
+                type: ComponentType.Button,
+                customId: modalButton.instanceId({
+                  data: { ...data, editOriginal: false },
+                  predicate: requireUser(interaction.user),
+                }),
+                style: ButtonStyle.Secondary,
+                label: t('config-role.button.edit'),
+              },
+            },
+            { type: ComponentType.Separator, spacing: 2 },
+            { type: ComponentType.TextDisplay, content: value },
+          ],
+          { accentColor: 0x01c3d9 },
+        ),
+      ],
+    } as const;
+
+    if (data.editOriginal) {
+      // update initial message
+      await interaction.editReply({
+        components: await renderPage(t, data.role.object.id, data.role, interaction),
+      });
+      // send a follow-up response
+      await interaction.followUp({
+        ...response,
+        flags: [MessageFlags.IsComponentsV2, MessageFlags.Ephemeral],
+      });
+    } else {
+      // just edit current follow up response
+      await interaction.editReply(response);
+    }
   },
 });

--- a/apps/bot/src/bot/commands/update-roles.ts
+++ b/apps/bot/src/bot/commands/update-roles.ts
@@ -4,7 +4,7 @@ import { DurationFormat } from '@formatjs/intl-durationformat';
 import { shards } from '#models/shardDb/shardDb.js';
 import { getGuildModel } from '#bot/models/guild/guildModel.js';
 import { getLevelProgression, sleep } from '#util/fct.js';
-import { checkRoleAssignment } from '#bot/levelManager.js';
+import { runRoleUpdate } from '#bot/levelManager.js';
 import {
   type AnyThreadChannel,
   ButtonStyle,
@@ -254,8 +254,7 @@ const run = component<{ members: Collection<string, GuildMember>; createHook: bo
         const xp = res.find((i) => i.userId === memberId)?.alltime ?? 0;
         const level = Math.floor(getLevelProgression(xp, cachedGuild.db.levelFactor));
 
-        // TODO: the whole checkRoleAssignment module needs a refactor
-        await checkRoleAssignment(discordMember, level);
+        await runRoleUpdate(discordMember, level);
         await sleep(1000); // sleep for 1 second
       }
 

--- a/apps/bot/src/bot/levelManager.ts
+++ b/apps/bot/src/bot/levelManager.ts
@@ -2,9 +2,12 @@ import fct from '../util/fct.js';
 import nameUtil from './util/nameUtil.js';
 import { getRoleModel } from './models/guild/guildRoleModel.js';
 import {
+  ComponentType,
   type DiscordAPIError,
-  EmbedBuilder,
+  type Guild,
   type GuildMember,
+  type MessageCreateOptions,
+  MessageFlags,
   RESTJSONErrorCodes,
   type Role,
 } from 'discord.js';
@@ -12,31 +15,121 @@ import { PermissionFlagsBits } from 'discord.js';
 import { getGuildModel } from './models/guild/guildModel.js';
 import { getMemberModel } from './models/guild/guildMemberModel.js';
 import { emoji } from '#const/config.js';
+import invariant from 'tiny-invariant';
+import { difference, symmetricDifference } from './util/typescript.js';
+import { warnGuild } from './util/warning.js';
 
-export async function checkLevelUp(
-  member: GuildMember,
-  oldTotalScore: number,
-  newTotalScore: number,
-) {
-  /* member.client.logger.debug(
-    { memberId: member.id, oldTotalScore, newTotalScore },
-    'checking levelup',
-  ); */
-
-  const cachedGuild = await getGuildModel(member.guild);
+/** Returns whether or not a member with the given scores would have levelled up. */
+export async function checkLevelup(guild: Guild, oldTotalScore: number, newTotalScore: number) {
+  const cachedGuild = await getGuildModel(guild);
 
   const oldLevel = fct.getLevel(fct.getLevelProgression(oldTotalScore, cachedGuild.db.levelFactor));
   const newLevel = fct.getLevel(fct.getLevelProgression(newTotalScore, cachedGuild.db.levelFactor));
 
-  // member.client.logger.debug({ oldLevel, newLevel }, 'checking levelup levels');
+  return { isLevelup: oldLevel !== newLevel, newLevel };
+}
 
-  if (oldLevel !== newLevel) {
-    const roleMessages = await checkRoleAssignment(member, newLevel);
-    await sendGratulationMessage(member, roleMessages, newLevel).catch((e) =>
-      member.client.logger.warn(e, 'Sending error while autoposting levelup message'),
-    );
+/**
+ * Sends a levelup message for the member. Check {@link checkLevelup} before running this function.
+ * If `newRoles` is not provided, the function will call {@link getNewMemberRoles} itself.
+ */
+export async function sendLevelupMessage(
+  member: GuildMember,
+  newLevel: number,
+  newRoles?: string[],
+): Promise<void> {
+  newRoles ??= await getNewMemberRoles(member, newLevel);
+  // TODO?: should we require roles to be assignable in
+  //     ?  `sendLevelupMessage` or just in `runRoleUpdate`?
+  const canAssign = await checkRolesAreAssignable(member, newLevel, newRoles);
+  if (canAssign.ok) {
+    const messages = await getRoleAssignmentMessages(member, newRoles);
+    await sendGratulationMessage(member, messages, newLevel);
+  } else {
+    // TODO: error handling
   }
 }
+
+export const alreadyWarnedGuilds = new Set();
+
+/**
+ * Checks that roles are assignable and attempts to assign roles to the given member.
+ * If `newRoles` is not provided, the function will call {@link getNewMemberRoles} itself.
+ */
+export async function runRoleUpdate(
+  member: GuildMember,
+  newLevel: number,
+  newRoles?: string[],
+): Promise<void> {
+  newRoles ??= await getNewMemberRoles(member, newLevel);
+  const canAssign = await checkRolesAreAssignable(member, newLevel, newRoles);
+  if (canAssign.ok) {
+    try {
+      await member.roles.set(newRoles);
+    } catch (err) {
+      member.client.logger.warn(
+        { err, memberId: member.id, guildId: member.guild.id, newLevel },
+        'Failed to set member roles on role update',
+      );
+    }
+  } else if (!alreadyWarnedGuilds.has(member.guild.id)) {
+    await warnGuild(
+      member.guild,
+      `## Warning\n${getWarningMessage(canAssign.errors, member.guild)}`,
+    );
+    alreadyWarnedGuilds.add(member.guild.id);
+  }
+}
+
+function getWarningMessage(errors: CheckAssignableRolesErr[], guild: Guild): string {
+  const response = [];
+
+  if (errors.some((err) => err.type === 'global')) {
+    response.push('### Global Permissions');
+    response.push(
+      'ActivityRank does not have **Assign Roles** permissions in this server. These permissions are required to make use of its functionality.',
+    );
+    response.push('');
+  }
+  if (errors.some((err) => err.type === 'localTooLow')) {
+    invariant(guild.members.me);
+    const ownRole = guild.members.me.roles.botRole;
+    const ownHighestRole = guild.members.me.roles.highest;
+    response.push('### Insufficient Permissions');
+    response.push(
+      `ActivityRank does not have a high enough role to manage some levelroles. Please ensure that ActivityRank's role (<@&${ownRole?.id}>) or another of its roles (for instance, its highest role, <@&${ownHighestRole.id}>) is above all level roles.`,
+    );
+    response.push('ActivityRank needs to be above the following roles:');
+    response.push(
+      ...errors.filter((err) => err.type === 'localTooLow').map((err) => `- <@&${err.roleId}>`),
+    );
+    response.push('');
+  }
+  if (errors.some((err) => err.type === 'localDangerous')) {
+    const formatter = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' });
+    const dangerous = formatter.format(dangerousPermissionsList);
+    response.push('### Dangerous Permissions');
+    response.push(
+      `As a safety measure, ActivityRank avoids assigning "dangerous" roles. Dangerous roles are those that have permissions that may cause harm to a server, such as ${dangerous}.`,
+    );
+    response.push('The following level roles have dangerous permissions:');
+    response.push(
+      ...errors.filter((err) => err.type === 'localDangerous').map((err) => `- <@&${err.roleId}>`),
+    );
+  }
+
+  return response.join('\n');
+}
+
+const dangerousPermissionsList = [
+  'Administrator',
+  'Ban Members',
+  'Kick Members',
+  'Manage Server',
+  'Manage Channels',
+  'Manage Roles',
+  'Manage Webhooks',
+];
 
 const DANGEROUS_PERMISSIONS =
   PermissionFlagsBits.KickMembers |
@@ -47,43 +140,150 @@ const DANGEROUS_PERMISSIONS =
   PermissionFlagsBits.ManageChannels |
   PermissionFlagsBits.ManageWebhooks;
 
-export async function checkRoleAssignment(member: GuildMember, level: number) {
-  const roleMessages: string[] = [];
-  const roles = member.guild.roles.cache;
+export async function getRoleAssignmentMessages(member: GuildMember, newRoles: string[]) {
+  const roleMessages: (string | null)[] = [];
+  const guildRoles = member.guild.roles.cache;
 
-  if (
-    roles.size === 0 ||
-    !member.guild.members.me?.permissions.has(PermissionFlagsBits.ManageRoles)
-  )
-    return roleMessages;
+  const rolesToCreate = difference(new Set(newRoles), new Set(member.roles.cache.keys()));
+  const rolesToDelete = difference(new Set(member.roles.cache.keys()), new Set(newRoles));
+
+  for (const roleId of rolesToCreate) {
+    const role = guildRoles.get(roleId);
+    if (!role) {
+      // This shouldn't occur, but if it does then something odd is going on with the caller of this function.
+      // newRoles should be a list of role IDs that are in the guild, so `role` should always exist.
+      throw new Error(
+        `Role "${roleId}" was provided via \`newRoles\` and is not a role in the guild.`,
+      );
+    }
+    roleMessages.push(await getRoleAssignMessage(member, role));
+  }
+
+  for (const roleId of rolesToDelete) {
+    const role = guildRoles.get(roleId);
+    invariant(
+      role,
+      "`roleId` is based on `member.roles.cache`, and all the roles of a member from a guild should exist in that guild's cache.",
+    );
+    roleMessages.push(await getRoleDeassignMessage(member, role));
+  }
+
+  return roleMessages.filter((i) => i !== null);
+}
+
+/**
+ * Returns a list of the role IDs a member should have after levelling up to level `level`.
+ *
+ * **A permissions check should be done after running this with {@link checkRolesAreAssignable}.**
+ *
+ * By default, the returned value will be a list of the roles the member currently has.
+ * If there are any changes that should be made, the returned list will reflect those changes.
+ */
+export async function getNewMemberRoles(member: GuildMember, level: number): Promise<string[]> {
+  invariant(member.guild.members.me);
+
+  const guildRoles = member.guild.roles.cache;
+  const memberRoles = new Set(member.roles.cache.keys());
+
+  if (guildRoles.size === 0) {
+    return [];
+  }
 
   const cachedGuild = await getGuildModel(member.guild);
 
-  /* member.client.logger.debug(
-    { memberId: member.id, guildId: member.guild.id, checkedLevel: level },
-    'checking roleAssigment',
-  ); */
-
-  for (const role of roles.values()) {
+  for (const role of guildRoles.values()) {
     const cachedRole = await getRoleModel(role);
-    //member.client.logger.debug({ cachedRole, role }, 'processing role');
 
-    if (cachedRole.db.assignLevel === 0 && cachedRole.db.deassignLevel === 0) continue;
-    if (role.comparePositionTo(member.guild.members.me?.roles.highest) > 0) continue;
+    if (cachedRole.db.assignLevel === 0 && cachedRole.db.deassignLevel === 0) {
+      // role is not part of the levelling system (can be ignored).
+      continue;
+    }
 
-    const memberHasRole = member.roles.cache.has(role.id);
+    const memberHasRole = memberRoles.has(role.id);
 
     if (cachedRole.db.deassignLevel !== 0 && level >= cachedRole.db.deassignLevel) {
-      // User is above role. Deassign or do nothing.
+      // User is above role. Should deassign.
       if (memberHasRole) {
-        await member.roles.remove(role).catch((e) => {
-          if (e.code !== 50013) throw e; // Missing Permissions
-        });
-        await addRoleDeassignMessage(roleMessages, member, role);
+        memberRoles.delete(role.id);
       }
     } else if (cachedRole.db.assignLevel !== 0 && level >= cachedRole.db.assignLevel) {
-      // User is within role. Assign or do nothing.
+      // User is within role. Try to assign.
+      if (!memberHasRole) {
+        memberRoles.add(role.id);
+      }
+    } else if (
+      cachedGuild.db.takeAwayAssignedRolesOnLevelDown &&
+      cachedRole.db.assignLevel !== 0 &&
+      level < cachedRole.db.assignLevel
+    ) {
+      // User is below role. Try to deassign.
+      if (memberHasRole) {
+        memberRoles.delete(role.id);
+      }
+    }
+  }
 
+  return [...memberRoles];
+}
+
+type CheckAssignableRolesResult = { ok: true } | { errors: CheckAssignableRolesErr[]; ok: false };
+type CheckAssignableRolesErr =
+  | { type: 'global'; description: string }
+  | { type: 'localTooLow'; roleId: string; description: string }
+  | { type: 'localDangerous'; roleId: string; description: string };
+
+/**
+ * Checks that the roles listed are assignable to the given member, if they are being updated at the listed level.
+ *
+ * This DOES NOT check all levelroles, just the ones that are going to be modified.
+ *
+ * If there are any invalid permissions (or other errors) found,
+ * `errors` will be populated and `ok` will be set to false.
+ */
+async function checkRolesAreAssignable(
+  member: GuildMember,
+  level: number,
+  roleIds: string[],
+): Promise<CheckAssignableRolesResult> {
+  invariant(member.guild.members.me);
+
+  const guildRoles = member.guild.roles.cache;
+  // const memberRoles = new Set(member.roles.cache.keys());
+
+  const modifiedRoles = symmetricDifference(new Set(roleIds), new Set(member.roles.cache.keys()));
+
+  const cachedGuild = await getGuildModel(member.guild);
+
+  const errors: CheckAssignableRolesErr[] = [];
+
+  if (!member.guild.members.me.permissions.has(PermissionFlagsBits.ManageRoles)) {
+    errors.push({
+      type: 'global',
+      description: 'The bot does not have Manage Roles permissions across the server.',
+    });
+  }
+
+  for (const role of guildRoles.values()) {
+    if (!modifiedRoles.has(role.id)) {
+      // role is not being edited right now (can be ignored).
+      continue;
+    }
+
+    const cachedRole = await getRoleModel(role);
+
+    if (role.comparePositionTo(member.guild.members.me.roles.highest) > 0) {
+      errors.push({
+        type: 'localTooLow',
+        roleId: role.id,
+        description: 'The bot does not have a high enough role to manage this role.',
+      });
+      continue;
+    }
+
+    if (cachedRole.db.deassignLevel !== 0 && level >= cachedRole.db.deassignLevel) {
+      // User is above role. Should deassign.
+    } else if (cachedRole.db.assignLevel !== 0 && level >= cachedRole.db.assignLevel) {
+      // User is within role. Try to assign.
       if (role.permissions.any(DANGEROUS_PERMISSIONS)) {
         member.client.logger.debug(
           {
@@ -95,66 +295,88 @@ export async function checkRoleAssignment(member: GuildMember, level: number) {
           },
           'attempted to assign dangerous role',
         );
-        continue;
-      }
-
-      if (!memberHasRole) {
-        //member.client.logger.debug({ roleId: role.id }, 'assigning role');
-        await member.roles.add(role).catch((e) => {
-          if (e.code !== 50013) throw e; // Missing Permissions
+        errors.push({
+          type: 'localDangerous',
+          roleId: role.id,
+          description: 'This role has dangerous permissions that the bot refuses to assign.',
         });
-        await addRoleAssignMessage(roleMessages, member, role);
+        // biome-ignore lint/correctness/noUnnecessaryContinue: keeping continue statement is clearer
+        continue;
       }
     } else if (
       cachedGuild.db.takeAwayAssignedRolesOnLevelDown &&
       cachedRole.db.assignLevel !== 0 &&
       level < cachedRole.db.assignLevel
     ) {
-      // User is below role. Deassign or do nothing.
-      if (memberHasRole) {
-        await member.roles.remove(role).catch((e) => {
-          if (e.code !== 50013) throw e; // Missing Permissions
-        });
-        await addRoleDeassignMessage(roleMessages, member, role);
-      }
+      // User is below role. Try to deassign.
     }
   }
 
-  return roleMessages;
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+  return { ok: true };
 }
 
 async function sendGratulationMessage(member: GuildMember, roleMessages: string[], level: number) {
-  let gratulationMessage = '';
+  const messages = [];
 
   const cachedGuild = await getGuildModel(member.guild);
   const cachedMember = await getMemberModel(member);
 
+  // `notifyLevelupWithRole`: when a role message is sent, also send the levelup
+  // message (otherwise the role message overwrites the levelup message).
   if (
     cachedGuild.db.levelupMessage !== '' &&
     (cachedGuild.db.notifyLevelupWithRole || roleMessages.length === 0)
   ) {
-    gratulationMessage += cachedGuild.db.levelupMessage;
-    gratulationMessage += '\n';
+    messages.push(cachedGuild.db.levelupMessage);
   }
 
   if (roleMessages.length > 0) {
-    gratulationMessage += roleMessages.join('\n');
-    gratulationMessage += '\n';
+    messages.push(...roleMessages);
   }
 
-  if (gratulationMessage === '') return;
+  if (messages.length === 0) {
+    return;
+  }
 
-  const ping = gratulationMessage.indexOf('<mention>') > -1 ? `<@${member.id}>` : '';
+  let content = messages.join('\n');
+  content = replaceTagsLevelup(content, member, level);
 
-  gratulationMessage = replaceTagsLevelup(gratulationMessage, member, level);
-
-  const levelupEmbed = new EmbedBuilder()
-    .setTitle(
-      `${nameUtil.getGuildMemberAlias(member, cachedGuild.db.showNicknames === 1)} ${emoji('level')}${level}`,
-    )
-    .setColor(0x01c3d9)
-    .setDescription(gratulationMessage)
-    .setThumbnail(member.user.avatarURL());
+  const message = (isDMs = false): MessageCreateOptions => ({
+    components: [
+      {
+        type: ComponentType.Container,
+        accentColor: 0x01c3d9,
+        components: [
+          {
+            type: ComponentType.Section,
+            components: [
+              {
+                type: ComponentType.TextDisplay,
+                content: `## ${nameUtil.getGuildMemberAlias(member, cachedGuild.db.showNicknames === 1)} ${emoji('level')}${level}`,
+              },
+            ],
+            accessory: { type: ComponentType.Thumbnail, media: { url: member.displayAvatarURL() } },
+          },
+          { type: ComponentType.TextDisplay, content },
+        ],
+      },
+      ...(isDMs
+        ? [
+            { type: ComponentType.Separator },
+            {
+              type: ComponentType.TextDisplay,
+              content:
+                '-# To disable direct messages from me, type `/config-member` in the server.',
+            },
+          ]
+        : []),
+    ],
+    allowedMentions: { parse: ['users'], users: [member.id] },
+    flags: [MessageFlags.IsComponentsV2],
+  });
 
   function handleGratulationMessageError(_err: unknown) {
     const err = _err as DiscordAPIError;
@@ -185,10 +407,9 @@ async function sendGratulationMessage(member: GuildMember, roleMessages: string[
           member.client.logger.warn(`lastMessageChannel ${channel.id} is not text-based`);
           return;
         }
-        const msg = { embeds: [levelupEmbed], content: ping };
 
         await channel
-          .send(msg)
+          .send(message())
           .then(() => {
             notified = true;
           })
@@ -207,10 +428,8 @@ async function sendGratulationMessage(member: GuildMember, roleMessages: string[
         return;
       }
 
-      const msg = { embeds: [levelupEmbed], content: ping };
-
       await channel
-        .send(msg)
+        .send(message())
         .then(() => {
           notified = true;
         })
@@ -220,13 +439,8 @@ async function sendGratulationMessage(member: GuildMember, roleMessages: string[
 
   // Direct Message
   if (!notified && cachedMember.db.notifyLevelupDm && cachedGuild.db.notifyLevelupDm) {
-    levelupEmbed.setFooter({
-      text: 'To disable direct messages from me, type `/config-member` in the server.',
-    });
-    const msg = { embeds: [levelupEmbed], content: ping };
-
     await member
-      .send(msg)
+      .send(message(true))
       .then(() => {
         notified = true;
       })
@@ -234,8 +448,8 @@ async function sendGratulationMessage(member: GuildMember, roleMessages: string[
   }
 }
 
-const addRoleDeassignMessage = async (roleMessages: string[], member: GuildMember, role: Role) => {
-  let message = '';
+async function getRoleDeassignMessage(member: GuildMember, role: Role): Promise<string | null> {
+  let message = null;
 
   const cachedRole = await getRoleModel(role);
   const cachedGuild = await getGuildModel(member.guild);
@@ -243,13 +457,12 @@ const addRoleDeassignMessage = async (roleMessages: string[], member: GuildMembe
   if (cachedRole.db.deassignMessage !== '') message = cachedRole.db.deassignMessage;
   else if (cachedGuild.db.roleDeassignMessage !== '') message = cachedGuild.db.roleDeassignMessage;
 
-  if (message !== '') roleMessages.push(replaceTagsRole(message, role));
+  if (message) return replaceTagsRole(message, role);
+  return null;
+}
 
-  return roleMessages;
-};
-
-const addRoleAssignMessage = async (roleMessages: string[], member: GuildMember, role: Role) => {
-  let message = '';
+async function getRoleAssignMessage(member: GuildMember, role: Role): Promise<string | null> {
+  let message = null;
 
   const cachedRole = await getRoleModel(role);
   const cachedGuild = await getGuildModel(member.guild);
@@ -257,28 +470,21 @@ const addRoleAssignMessage = async (roleMessages: string[], member: GuildMember,
   if (cachedRole.db.assignMessage !== '') message = cachedRole.db.assignMessage;
   else if (cachedGuild.db.roleAssignMessage !== '') message = cachedGuild.db.roleAssignMessage;
 
-  if (message !== '') roleMessages.push(replaceTagsRole(message, role));
+  if (message) return replaceTagsRole(message, role);
+  return null;
+}
 
-  return roleMessages;
-};
-
-const replaceTagsRole = (text: string, role: Role) => {
+function replaceTagsRole(text: string, role: Role) {
   return text
     .replace(/<rolename>/g, role.name)
     .replace(/<role>/g, role.name)
     .replace(/<rolemention>/g, role.toString());
-};
+}
 
-const replaceTagsLevelup = (text: string, member: GuildMember, level: number) => {
-  const res = text
+function replaceTagsLevelup(text: string, member: GuildMember, level: number) {
+  return text
     .replace(/<mention>/g, `<@${member.id}>`)
     .replace(/<name>/g, member.user.username)
     .replace(/<level>/g, level.toString())
     .replace(/<servername>/g, member.guild.name);
-  return `${res}\n`;
-};
-
-export default {
-  checkLevelUp,
-  checkRoleAssignment,
-};
+}

--- a/apps/bot/src/bot/util/typescript.ts
+++ b/apps/bot/src/bot/util/typescript.ts
@@ -51,3 +51,28 @@ export type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 export type PartiallyRequired<T, K extends keyof T> = { [k in K]-?: T[k] } & {
   [k in keyof T]: T[k];
 };
+
+// TODO: consider allowing `Iterable`s instead of only `Set`s as inputs
+
+export function intersection<T>(a: Set<T>, b: Set<T>): Set<T> {
+  return new Set([...a].filter((e) => b.has(e)));
+}
+
+export function difference<T>(a: Set<T>, b: Set<T>): Set<T> {
+  return new Set([...a].filter((e) => !b.has(e)));
+}
+
+export function union<T>(a: Set<T>, b: Set<T>): Set<T> {
+  return new Set([...a, ...b]);
+}
+
+// see https://tc39.es/ecma262/#sec-set.prototype.symmetricdifference
+export function symmetricDifference<T>(a: Set<T>, b: Set<T>): Set<T> {
+  const res = new Set(a);
+  for (const next of b) {
+    const alreadyIn = res.has(next);
+    if (a.has(next) && alreadyIn) res.delete(next);
+    else if (!alreadyIn) res.add(next);
+  }
+  return res;
+}

--- a/apps/bot/src/bot/util/warning.ts
+++ b/apps/bot/src/bot/util/warning.ts
@@ -58,6 +58,13 @@ export async function warnGuild(guild: Guild, content: string) {
         {
           type: ComponentType.Container,
           accentColor: 0xd97706,
+          components: [
+            { type: ComponentType.TextDisplay, content: `Warning from **${guild.name}**` },
+          ],
+        },
+        {
+          type: ComponentType.Container,
+          accentColor: 0xd97706,
           components: [{ type: ComponentType.TextDisplay, content }],
         },
       ],

--- a/apps/bot/src/bot/util/warning.ts
+++ b/apps/bot/src/bot/util/warning.ts
@@ -40,10 +40,10 @@ export async function warnGuild(guild: Guild, content: string) {
   const levelupChannel = await guild.channels.fetch(guildModel.db.autopost_levelup);
   const joinChannel = await guild.channels.fetch(guildModel.db.autopost_serverJoin);
 
-  await tryToSend(levelupChannel);
-  await tryToSend(joinChannel);
   await tryToSend(guild.safetyAlertsChannel);
   await tryToSend(guild.publicUpdatesChannel);
+  await tryToSend(levelupChannel);
+  await tryToSend(joinChannel);
   await tryToSend(guild.systemChannel);
 
   if (success) {

--- a/apps/bot/src/bot/util/warning.ts
+++ b/apps/bot/src/bot/util/warning.ts
@@ -1,0 +1,70 @@
+import { getGuildModel } from '#bot/models/guild/guildModel.js';
+import { ComponentType, MessageFlags, type Channel, type Guild } from 'discord.js';
+import invariant from 'tiny-invariant';
+
+export async function warnGuild(guild: Guild, content: string) {
+  let success = false;
+
+  async function tryToSend(channel?: Channel | null) {
+    if (!channel || success) {
+      return;
+    }
+    if (!channel.isSendable()) {
+      return;
+    }
+
+    invariant(guild.members.me);
+    if (!channel.isDMBased() && !guild.members.me.permissionsIn(channel).has('SendMessages')) {
+      return;
+    }
+
+    try {
+      await channel.send({
+        components: [
+          {
+            type: ComponentType.Container,
+            accentColor: 0xd97706,
+            components: [{ type: ComponentType.TextDisplay, content }],
+          },
+        ],
+        allowedMentions: { parse: [] },
+        flags: MessageFlags.IsComponentsV2,
+      });
+      success = true;
+    } catch (e) {
+      // TODO: consider logging here?
+    }
+  }
+
+  const guildModel = await getGuildModel(guild);
+  const levelupChannel = await guild.channels.fetch(guildModel.db.autopost_levelup);
+  const joinChannel = await guild.channels.fetch(guildModel.db.autopost_serverJoin);
+
+  await tryToSend(levelupChannel);
+  await tryToSend(joinChannel);
+  await tryToSend(guild.safetyAlertsChannel);
+  await tryToSend(guild.publicUpdatesChannel);
+  await tryToSend(guild.systemChannel);
+
+  if (success) {
+    return;
+  }
+
+  const owner = await guild.fetchOwner();
+
+  try {
+    await owner.send({
+      components: [
+        {
+          type: ComponentType.Container,
+          accentColor: 0xd97706,
+          components: [{ type: ComponentType.TextDisplay, content }],
+        },
+      ],
+      flags: MessageFlags.IsComponentsV2,
+    });
+    success = true;
+  } catch (e) {
+    // TODO: consider logging here?
+  }
+}

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -21,6 +21,9 @@
     "enabled": true,
     "rules": {
       "recommended": true,
+      "style": {
+        "noParameterAssign": "info"
+      },
       "suspicious": {
         // TODO: turn this lint back on
         "noExplicitAny": "off"


### PR DESCRIPTION
* Modularizes `bot/levelManager.ts`
* Cleans up `/config-messages` flow and adds a **Test** button
* Improves `/config-role menu`
* Sends a warning in the first of the below channels it has access to, if permission errors are present when reassigning roles:
  * Levelup channel
  * Server Join channel
  * Discord Safety Alerts channel
  * Discord Public Updates channel
  * Discord System channel
  * Guild Owner's DMs