### PR TITLE
feat: update ask for Premium messages

### DIFF
--- a/.changeset/cold-spoons-write.md
+++ b/.changeset/cold-spoons-write.md
@@ -1,0 +1,5 @@
+---
+"@activityrank/cli": patch
+---
+
+update to use new config loader API

--- a/.changeset/cyan-humans-fall.md
+++ b/.changeset/cyan-humans-fall.md
@@ -1,0 +1,5 @@
+---
+"@activityrank/bot": minor
+---
+
+Ask for premium in cooldownUtil

--- a/.changeset/dry-tools-rule.md
+++ b/.changeset/dry-tools-rule.md
@@ -1,0 +1,5 @@
+---
+"@activityrank/bot": minor
+---
+
+Improve ask for premium message (directs to Discord Shop as the way to subscribe to servers)

--- a/.changeset/dull-owls-search.md
+++ b/.changeset/dull-owls-search.md
@@ -1,0 +1,5 @@
+---
+"@activityrank/cli": minor
+---
+
+Add file-formatting abstraction

--- a/apps/bot/locales/en-US/command-content.json
+++ b/apps/bot/locales/en-US/command-content.json
@@ -336,5 +336,9 @@
     "confirm": "Confirm",
     "cancel": "Cancel",
     "success": "Your inviter has been set successfully. You will both get 1 invite added to your stats."
+  },
+  "cooldown": {
+    "statcommands": "{{prefix}} You can use stat commands only once per {{duration}}. You can use this command again {{countdown}}.",
+    "resetcommands": "{{prefix}} You can start a server reset only once per {{duration}}. You can use this command again {{countdown}}."
   }
 }

--- a/apps/bot/locales/en-US/command-descriptions.json
+++ b/apps/bot/locales/en-US/command-descriptions.json
@@ -97,6 +97,7 @@
   "config-xp.xp-per-role.invite": "The amount of XP gained per member invited to the server",
   "bonus.role.role": "Change the bonus XP of all members with a given role.",
   "update-roles": "Resync all activity roles for every user in the server",
+  "leaderboard": "Send a persistent, auto-updating leaderboard.",
   "blacklist.user": "Blacklist a user from the bot.",
   "blacklist.user.user": "The user to blacklist",
   "blacklist.guild": "Blacklist a guild from the bot.",

--- a/apps/bot/src/bot/commands/memberinfo.ts
+++ b/apps/bot/src/bot/commands/memberinfo.ts
@@ -13,12 +13,12 @@ import nameUtil, { getGuildMemberInfo } from '../util/nameUtil.js';
 
 export default command({
   name: 'memberinfo',
-  async execute({ interaction, options }) {
+  async execute({ interaction, options, t }) {
     const member = (await resolveMember(options.member, interaction)) ?? interaction.member;
 
     const cachedGuild = await getGuildModel(interaction.guild);
 
-    if ((await handleStatCommandsCooldown(interaction)).denied) return;
+    if ((await handleStatCommandsCooldown(t, interaction)).denied) return;
 
     const userModel = await getUserModel(member.user);
     const myTargetUser = await userModel.fetch();

--- a/apps/bot/src/bot/commands/rank.ts
+++ b/apps/bot/src/bot/commands/rank.ts
@@ -52,7 +52,7 @@ export default command({
   async execute({ interaction, client, options, t }) {
     await interaction.deferReply();
 
-    if ((await handleStatCommandsCooldown(interaction)).denied) return;
+    if ((await handleStatCommandsCooldown(t, interaction)).denied) return;
 
     const cachedGuild = await getGuildModel(interaction.guild);
     const myGuild = await cachedGuild.fetch();

--- a/apps/bot/src/bot/commands/reset/server/all.ts
+++ b/apps/bot/src/bot/commands/reset/server/all.ts
@@ -16,7 +16,7 @@ export default command({
       return;
     }
 
-    if ((await handleResetCommandsCooldown(interaction)).denied) return;
+    if ((await handleResetCommandsCooldown(t, interaction)).denied) return;
 
     const predicate = requireUser(interaction.user);
     const confirmRow = new ActionRowBuilder<ButtonBuilder>().addComponents(

--- a/apps/bot/src/bot/commands/reset/server/members.ts
+++ b/apps/bot/src/bot/commands/reset/server/members.ts
@@ -7,7 +7,7 @@ import { requireUser } from '#bot/util/predicates.js';
 
 export default command({
   name: 'reset server members',
-  async execute({ interaction }) {
+  async execute({ interaction, t }) {
     if (
       interaction.channel &&
       !interaction.member.permissionsIn(interaction.channel).has(PermissionFlagsBits.ManageGuild)
@@ -19,7 +19,7 @@ export default command({
       return;
     }
 
-    if ((await handleResetCommandsCooldown(interaction)).denied) return;
+    if ((await handleResetCommandsCooldown(t, interaction)).denied) return;
 
     const predicate = requireUser(interaction.user);
 

--- a/apps/bot/src/bot/commands/reset/server/settings.ts
+++ b/apps/bot/src/bot/commands/reset/server/settings.ts
@@ -16,7 +16,7 @@ export default command({
       return;
     }
 
-    if ((await handleResetCommandsCooldown(interaction)).denied) return;
+    if ((await handleResetCommandsCooldown(t, interaction)).denied) return;
 
     const predicate = requireUser(interaction.user);
     const confirmRow = new ActionRowBuilder<ButtonBuilder>().addComponents(

--- a/apps/bot/src/bot/commands/reset/server/statistics.ts
+++ b/apps/bot/src/bot/commands/reset/server/statistics.ts
@@ -25,7 +25,7 @@ export default command({
       return;
     }
 
-    if ((await handleResetCommandsCooldown(interaction)).denied) return;
+    if ((await handleResetCommandsCooldown(t, interaction)).denied) return;
 
     const predicate = requireUser(interaction.user);
 

--- a/apps/bot/src/bot/commands/reset/server/xp.ts
+++ b/apps/bot/src/bot/commands/reset/server/xp.ts
@@ -16,7 +16,7 @@ export default command({
       return;
     }
 
-    if ((await handleResetCommandsCooldown(interaction)).denied) return;
+    if ((await handleResetCommandsCooldown(t, interaction)).denied) return;
 
     const predicate = requireUser(interaction.user);
 

--- a/apps/bot/src/bot/commands/top.ts
+++ b/apps/bot/src/bot/commands/top.ts
@@ -68,12 +68,12 @@ interface CacheInstance {
 
 export default command({
   name: 'top',
-  async execute({ interaction }) {
+  async execute({ interaction, t }) {
     await interaction.deferReply();
 
     const cachedGuild = await getGuildModel(interaction.guild);
 
-    if ((await handleStatCommandsCooldown(interaction)).denied) return;
+    if ((await handleStatCommandsCooldown(t, interaction)).denied) return;
 
     const initialState: CacheInstance = {
       window: 'members',

--- a/apps/bot/src/bot/commandsAdmin/shard-status.ts
+++ b/apps/bot/src/bot/commandsAdmin/shard-status.ts
@@ -1,5 +1,6 @@
-import { DurationFormatter } from '@sapphire/duration';
+import { DurationFormat } from '@formatjs/intl-durationformat';
 import { AttachmentBuilder, EmbedBuilder, Status } from 'discord.js';
+import { Temporal } from 'temporal-polyfill';
 import { command } from '#bot/commands.js';
 import { HELPSTAFF_ONLY } from '#bot/util/predicates.js';
 import { managerFetch } from '../../models/managerDb/managerDb.js';
@@ -91,13 +92,16 @@ export default command({
   },
 });
 
-const durationFormatter = new DurationFormatter();
+const durationFormatter = new DurationFormat('en-US', { style: 'long' });
 
 function parseShardInfoContent(shard: Omit<APIShard, 'ip'>) {
+  let uptime = Temporal.Duration.from({ seconds: shard.uptimeSeconds });
+  uptime = uptime.round({ smallestUnit: 'minutes', largestUnit: 'weeks' });
+
   return [
     `  **Status**: \`${shard.status === 0 ? '🟢 Online' : `🔴 ${Status[shard.status]}`}\``,
     `  **Guilds**: \`${shard.serverCount.toLocaleString()}\``,
-    `  **Uptime**: \`${durationFormatter.format(shard.uptimeSeconds * 1000, 3)}\` since <t:${
+    `  **Uptime**: \`${durationFormatter.format(uptime)}\` since <t:${
       shard.readyDate
     }:f>, <t:${shard.readyDate}:R>`,
     `  **Last updated**: <t:${shard.changedHealthDate}:T>, <t:${shard.changedHealthDate}:R>`,

--- a/apps/bot/src/bot/events/interactionCreate.ts
+++ b/apps/bot/src/bot/events/interactionCreate.ts
@@ -15,7 +15,7 @@ import { registry } from '#bot/util/registry/registry.js';
 import { config } from '#const/config.js';
 import { getGuildModel } from '../models/guild/guildModel.js';
 import { getUserModel } from '../models/userModel.js';
-import askForPremium from '../util/askForPremium.js';
+import { askForPremium } from '../util/askForPremium.js';
 
 export default event(Events.InteractionCreate, async (interaction) => {
   try {

--- a/apps/bot/src/bot/util/askForPremium.ts
+++ b/apps/bot/src/bot/util/askForPremium.ts
@@ -3,9 +3,9 @@ import { getGuildModel } from '#bot/models/guild/guildModel.js';
 import { emoji } from '#const/config.js';
 import fct, { hasValidEntitlement } from '../../util/fct.js';
 import { getUserModel } from '../models/userModel.js';
+import { section } from './component.js';
 import { PATREON_BUTTON, PATREON_URL, PREMIUM_BUTTON } from './constants.js';
 import { getWaitTime } from './cooldownUtil.js';
-import { section } from './component.js';
 import { oneline } from './templateStrings.js';
 
 const isDev = process.env.NODE_ENV !== 'production';

--- a/apps/bot/src/bot/util/component.ts
+++ b/apps/bot/src/bot/util/component.ts
@@ -72,6 +72,10 @@ export function section(
   return { type: ComponentType.Section, components, accessory };
 }
 
+export function textDisplay(content: string, id?: number): APITextDisplayComponent {
+  return { type: ComponentType.TextDisplay, content, id };
+}
+
 /**
  * Create a button that deletes the current message when pressed.
  */

--- a/apps/bot/src/bot/util/component.ts
+++ b/apps/bot/src/bot/util/component.ts
@@ -1,6 +1,9 @@
 import {
   type ActionRowData,
-  type ButtonComponentData,
+  type APIButtonComponent,
+  type APISectionComponent,
+  type APITextDisplayComponent,
+  type APIThumbnailComponent,
   type ButtonInteraction,
   type ComponentInContainerData,
   ComponentType,
@@ -8,9 +11,6 @@ import {
   type MessageActionRowComponentBuilder,
   type MessageActionRowComponentData,
   type ModalActionRowComponentData,
-  type SectionComponentData,
-  type TextDisplayComponentData,
-  type ThumbnailComponentData,
 } from 'discord.js';
 import { type ComponentCallback, component } from './registry/component.js';
 
@@ -58,10 +58,10 @@ export function container(
 }
 
 export function section(
-  _components: TextDisplayComponentData | TextDisplayComponentData[],
-  accessory: ButtonComponentData | ThumbnailComponentData,
-): SectionComponentData {
-  let components: TextDisplayComponentData[];
+  _components: APITextDisplayComponent | APITextDisplayComponent[],
+  accessory: APIButtonComponent | APIThumbnailComponent,
+): APISectionComponent {
+  let components: APITextDisplayComponent[];
 
   if (Array.isArray(_components)) {
     components = _components;

--- a/apps/bot/src/bot/util/component.ts
+++ b/apps/bot/src/bot/util/component.ts
@@ -1,5 +1,6 @@
 import {
   type ActionRowData,
+  type ButtonComponentData,
   type ButtonInteraction,
   type ComponentInContainerData,
   ComponentType,
@@ -7,6 +8,9 @@ import {
   type MessageActionRowComponentBuilder,
   type MessageActionRowComponentData,
   type ModalActionRowComponentData,
+  type SectionComponentData,
+  type TextDisplayComponentData,
+  type ThumbnailComponentData,
 } from 'discord.js';
 import { type ComponentCallback, component } from './registry/component.js';
 
@@ -51,6 +55,21 @@ export function container(
   opts?: Omit<ContainerComponentData, 'type' | 'components'>,
 ): ContainerComponentData {
   return { type: ComponentType.Container, components, ...opts };
+}
+
+export function section(
+  _components: TextDisplayComponentData | TextDisplayComponentData[],
+  accessory: ButtonComponentData | ThumbnailComponentData,
+): SectionComponentData {
+  let components: TextDisplayComponentData[];
+
+  if (Array.isArray(_components)) {
+    components = _components;
+  } else {
+    components = [_components];
+  }
+
+  return { type: ComponentType.Section, components, accessory };
 }
 
 /**

--- a/apps/bot/src/bot/util/constants.ts
+++ b/apps/bot/src/bot/util/constants.ts
@@ -1,20 +1,49 @@
 import {
   type APIActionRowComponent,
-  type APIComponentInActionRow,
+  type APIButtonComponent,
+  type APIButtonComponentWithSKUId,
+  type APIButtonComponentWithURL,
   ButtonStyle,
   ComponentType,
 } from 'discord.js';
+import { emojiId, isProduction } from '#const/config.js';
+import { ComponentKey } from './registry/component.js';
+
+export const PREMIUM_SKU_ID = '1393334749568696361';
+
+// Premiium buttons cannot be sent by non-premium bots, so we use a placeholder button in development
+// and a real premium button in production.
+export const PREMIUM_BUTTON: APIButtonComponentWithSKUId = isProduction
+  ? {
+      type: ComponentType.Button,
+      style: ButtonStyle.Premium,
+      sku_id: PREMIUM_SKU_ID,
+    }
+  : ({
+      type: ComponentType.Button,
+      style: ButtonStyle.Primary,
+      label: 'SAMPLE PREMIUM BUTTON',
+      emoji: { id: emojiId('store') },
+      custom_id: ComponentKey.Ignore,
+    } as APIButtonComponent as APIButtonComponentWithSKUId);
+
+export const PREMIUM_ACTION_ROW: APIActionRowComponent<APIButtonComponentWithSKUId> = {
+  type: ComponentType.ActionRow,
+  components: [PREMIUM_BUTTON],
+};
+
+export const PREMIUM_COMPONENTS = [PREMIUM_ACTION_ROW];
 
 export const PATREON_URL = 'https://www.patreon.com/rapha01';
 
-export const PATREON_BUTTON: APIComponentInActionRow = {
+export const PATREON_BUTTON: APIButtonComponentWithURL = {
   type: ComponentType.Button,
   style: ButtonStyle.Link,
   url: PATREON_URL,
   label: 'Support us on Patreon!',
 };
 
-export const PATREON_ACTION_ROW: APIActionRowComponent<APIComponentInActionRow> = {
+export const PATREON_ACTION_ROW: APIActionRowComponent<APIButtonComponentWithURL> = {
   type: ComponentType.ActionRow,
   components: [PATREON_BUTTON],
 };

--- a/apps/bot/src/bot/util/registry/commands.generated.ts
+++ b/apps/bot/src/bot/util/registry/commands.generated.ts
@@ -1,13 +1,11 @@
-/* 🛠️ This file was generated with `activityrank generate` on Wed Jun 18 2025. */
+/* 🛠️ This file was generated with `activityrank generate` on Mon Aug 18 2025. */
 
 import type {
-  Attachment,
   AutocompleteInteraction,
   ChannelType,
   ChatInputCommandInteraction,
   Client,
   GuildChannel,
-  MessageContextMenuCommandInteraction,
   Role,
   ThreadChannel,
   User,
@@ -499,6 +497,15 @@ export function command(options: {
   }) => CommandReturn;
 }): Command;
 export function command(options: {
+  name: 'leaderboard';
+  predicate?: CommandPredicateConfig;
+  execute: (args: {
+    interaction: ChatInputCommandInteraction<'cached'>;
+    client: Client;
+    t: TFunction<'command-content'>;
+  }) => CommandReturn;
+}): Command;
+export function command(options: {
   name: 'blacklist user';
   predicate?: CommandPredicateConfig;
   execute: (args: {
@@ -682,6 +689,7 @@ export const COMMAND_META: {
   top: { optionGetters: {}, type: 'base-command' },
   rank: { optionGetters: { member: ['user'] }, type: 'base-command' },
   'update-roles': { optionGetters: {}, type: 'base-command' },
+  leaderboard: { optionGetters: {}, type: 'base-command' },
   'blacklist user': { optionGetters: { user: ['user'] }, type: 'subcommand' },
   'blacklist guild': { optionGetters: { id: ['value'] }, type: 'subcommand' },
   eval: {

--- a/apps/bot/src/bot/util/templateStrings.ts
+++ b/apps/bot/src/bot/util/templateStrings.ts
@@ -1,0 +1,23 @@
+// https://adamcoster.com/blog/prettify-your-javascript-strings
+
+/**
+ * Concatenate the string fragments and interpolated values
+ * to get a single string.
+ */
+function populateTemplate(strings: TemplateStringsArray, ...interps: string[]) {
+  let string = '';
+  for (let i = 0; i < strings.length; i++) {
+    string += `${strings[i] || ''}${interps[i]?.toString() || ''}`;
+  }
+  return string;
+}
+
+/**
+ * Remove linebreaks and extra spacing in a template string.
+ */
+export function oneline(strings: TemplateStringsArray, ...interps: string[]) {
+  return populateTemplate(strings, ...interps)
+    .replace(/^\s+/, '')
+    .replace(/\s+$/, '')
+    .replace(/\s+/g, ' ');
+}

--- a/apps/bot/src/const/config.ts
+++ b/apps/bot/src/const/config.ts
@@ -18,6 +18,13 @@ export function emoji(name: EmojiNames) {
   }
   return `<:${name}:${id}>`;
 }
+export function emojiId(name: EmojiNames) {
+  const id = emojiIds[name];
+  if (!id) {
+    throw new Error(`Failed to resolve bot emoji "${name}".`);
+  }
+  return id;
+}
 
 const pkgfile = await readFile(packageFile);
 const pkg = JSON.parse(pkgfile.toString());

--- a/apps/bot/src/util/fct.ts
+++ b/apps/bot/src/util/fct.ts
@@ -1,6 +1,7 @@
 import type { ShardDB } from '@activityrank/database';
 import type { BaseInteraction, Entitlement, GuildMember } from 'discord.js';
 import { getRoleModel } from '#bot/models/guild/guildRoleModel.js';
+import { PREMIUM_SKU_ID } from '#bot/util/constants.js';
 import { getUserModel } from '../bot/models/userModel.js';
 
 // System
@@ -61,8 +62,6 @@ function solve(a: number, b: number, c: number) {
   if (result2 >= 0) return result2;
   return null;
 }
-
-const PREMIUM_SKU_ID = '1393334749568696361';
 
 export function hasValidEntitlement(interaction: BaseInteraction<'cached'>) {
   function isValidEntitlement(entitlement: Entitlement) {

--- a/apps/cli/src/commands/deploy.ts
+++ b/apps/cli/src/commands/deploy.ts
@@ -1,4 +1,5 @@
 import * as p from '@clack/prompts';
+import type { RESTPutAPIApplicationCommandsJSONBody } from '@discordjs/core';
 import { Command, Option } from 'clipanion';
 import type { RESTPutAPIApplicationGuildCommandsJSONBody } from 'discord-api-types/v10';
 import pc from 'picocolors';
@@ -57,7 +58,7 @@ export class DeployCommand extends ConfigurableCommand2 {
 
     const commands = await this.getDeployableCommands();
 
-    const globalCommands: RESTPutAPIApplicationGuildCommandsJSONBody = commands.filter(
+    const globalCommands: RESTPutAPIApplicationCommandsJSONBody = commands.filter(
       (c) => c.deployment === Deploy.Global,
     );
     const localCommands: RESTPutAPIApplicationGuildCommandsJSONBody =

--- a/apps/cli/src/commands/emoji.ts
+++ b/apps/cli/src/commands/emoji.ts
@@ -8,6 +8,7 @@ import pc from 'picocolors';
 import TOML from 'smol-toml';
 import { z } from 'zod/v4';
 import { ConfigurableCommand2 } from '../util/classes.ts';
+import { formatFile } from '../util/format.ts';
 import { findWorkspaceRoot } from '../util/loaders.ts';
 
 export class EmojiDeployCommand extends ConfigurableCommand2 {
@@ -161,6 +162,10 @@ export class EmojiDeployCommand extends ConfigurableCommand2 {
       ].join('\n'),
     );
 
+    if (outputDisplay === 'stdout') {
+      await formatFile(outputDisplay);
+    }
+
     if (!this.updateConfig) {
       p.outro(`Emoji typings written to ${pc.gray(outputDisplay)}`);
       return;
@@ -199,6 +204,7 @@ export class EmojiDeployCommand extends ConfigurableCommand2 {
       emojiFilePath,
       JSON.stringify(Object.fromEntries(currentEmojis.items.map((e) => [e.name, e.id])), null, 2),
     );
+    await formatFile(emojiFilePath);
 
     p.outro(`Emoji IDs written to ${pc.gray('config/emoji.json')}`);
   }

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -1,5 +1,6 @@
 import { createWriteStream } from 'node:fs';
 import type { Writable } from 'node:stream';
+import type { schemas } from '@activityrank/cfg';
 import * as p from '@clack/prompts';
 import type { API } from '@discordjs/core';
 import { Command, Option, UsageError } from 'clipanion';
@@ -7,8 +8,8 @@ import { createConnection, type RowDataPacket } from 'mysql2/promise';
 import pc from 'picocolors';
 import TOML from 'smol-toml';
 import t from 'typanion';
+import type z from 'zod';
 import { ConfigurableCommand2 } from '../util/classes.ts';
-import type { BaseConfig } from '../util/loaders.ts';
 
 const FORMATS = ['table', 'csv', 'json', 'toml'] as const;
 type OutputFormat = (typeof FORMATS)[number];
@@ -202,7 +203,7 @@ export class ExportCommand extends ConfigurableCommand2 {
 
   async loadDatabaseEntries(
     guildId: string,
-    keys: BaseConfig['keys'],
+    keys: z.infer<typeof schemas.bot.keys>,
   ): Promise<{ userId: string; xp: number }[]> {
     const manager = await createConnection({
       host: keys.managerHost,

--- a/apps/cli/src/commands/generate.ts
+++ b/apps/cli/src/commands/generate.ts
@@ -355,7 +355,7 @@ export class GenerateCommand extends ConfigurableCommand2 {
     p.intro('Generating command typings');
 
     const loader = await this.getConfigLoader();
-    const commands = await loader.load({ name: 'commands', schema: commandsSchema, secret: false });
+    const commands = await loader.loadConfig('commands', { schema: commandsSchema });
 
     const output = [
       `/* 🛠️ This file was generated with \`activityrank generate\` on ${new Date().toDateString()}. */\n\n`,

--- a/apps/cli/src/commands/generate.ts
+++ b/apps/cli/src/commands/generate.ts
@@ -11,7 +11,6 @@ import {
   ChannelType,
   InteractionContextType,
 } from 'discord-api-types/v10';
-import { $ } from 'execa';
 import pc from 'picocolors';
 import type { z } from 'zod/v4';
 import { ConfigurableCommand2 } from '../util/classes.ts';
@@ -21,6 +20,7 @@ import {
   commandsSchema,
   type subcommandOptionSchema,
 } from '../util/commandSchema.ts';
+import { formatFile } from '../util/format.ts';
 import { findWorkspaceRoot } from '../util/loaders.ts';
 
 class ObjectTypeBuilder {
@@ -432,7 +432,7 @@ export class GenerateCommand extends ConfigurableCommand2 {
     await promisify(outputStream.end.bind(outputStream))();
 
     if (outputDisplay !== 'stdout' && this.postGen !== false) {
-      await $`pnpm exec biome format --write ${outputDisplay}`;
+      await formatFile(outputDisplay);
     }
 
     p.outro(`Command typings written to ${pc.gray(outputDisplay)}`);

--- a/apps/cli/src/commands/validate.ts
+++ b/apps/cli/src/commands/validate.ts
@@ -19,7 +19,7 @@ export class ValidateCommand extends ConfigurableCommand2 {
     spin.start('Validating config...');
 
     const loader = await this.getConfigLoader();
-    await loader.load({ name: 'commands', schema: commandsSchema, secret: false });
+    await loader.loadConfig('commands', { schema: commandsSchema });
 
     spin.stop(pc.green('✔︎ commands.json validated'));
   }

--- a/apps/cli/src/util/classes.ts
+++ b/apps/cli/src/util/classes.ts
@@ -22,7 +22,7 @@ import {
   type subcommandGroupOptionSchema,
   type subcommandOptionSchema,
 } from './commandSchema.ts';
-import { type BaseConfig, findWorkspaceRoot } from './loaders.ts';
+import { findWorkspaceRoot } from './loaders.ts';
 
 export abstract class ConfigurableCommand2 extends Command {
   hideConfigPath = false;
@@ -257,6 +257,13 @@ export abstract class ConfigurableCommand2 extends Command {
 
     return commands;
   }
+}
+
+interface BaseConfig {
+  config: z.infer<typeof schemas.bot.config>;
+  keys: z.infer<typeof schemas.bot.keys>;
+  api: API;
+  loader: Awaited<ReturnType<typeof configLoader>>;
 }
 
 export class ConfigurableCommand extends Command {

--- a/apps/cli/src/util/format.ts
+++ b/apps/cli/src/util/format.ts
@@ -1,0 +1,5 @@
+import { $ } from 'execa';
+
+export async function formatFile(path: string, { unsafe = true } = {}) {
+  await $`pnpm exec biome check --write ${unsafe ? '--unsafe' : ''} "${path}"`;
+}

--- a/apps/cli/src/util/loaders.ts
+++ b/apps/cli/src/util/loaders.ts
@@ -1,10 +1,7 @@
 import path from 'node:path';
-import type { configLoader, schemas } from '@activityrank/cfg';
-import type { API } from '@discordjs/core';
 import { findWorkspaceDir } from '@pnpm/find-workspace-dir';
 import { UsageError } from 'clipanion';
 import pc from 'picocolors';
-import type { z } from 'zod/v4';
 
 export async function findWorkspaceRoot(errorMessage?: string) {
   const workspaceDir = await findWorkspaceDir(process.cwd());
@@ -21,52 +18,3 @@ export async function findWorkspaceConfig() {
   const root = await findWorkspaceRoot();
   return path.join(root, 'config');
 }
-
-// /**
-//  * Gets a configLoader object, from (in order):
-//  *
-//  * 1. the provided path argument
-//  * 2. the CONFIG_PATH environment variable
-//  * 3. the workspace root
-//  */
-// export async function getConfigLoader(
-//   _path?: string | undefined,
-// ): Promise<ReturnType<typeof configLoader>> {
-//   const cfgPath =
-//     _path ?? process.env.CONFIG_PATH ?? path.join(await findWorkspaceRoot(), 'config');
-//   return configLoader(cfgPath);
-// }
-
-export interface BaseConfig {
-  config: z.infer<typeof schemas.bot.config>;
-  keys: z.infer<typeof schemas.bot.keys>;
-  api: API;
-  loader: Awaited<ReturnType<typeof configLoader>>;
-}
-
-// /**
-//  * Loads frequently-required config objects, like the config and keys from:
-//  *
-//  * 1. the provided path argument
-//  * 2. the CONFIG_PATH environment variable
-//  * 3. the workspace root
-//  *
-//  * If only the `configLoader` object is required, prefer {@link getConfigLoader}
-//  * as it will avoid validating the `config.json` and `keys.json` files.
-//  */
-// export async function loadBaseConfig(configDirPath?: string | undefined): Promise<BaseConfig> {
-//   const loader = await getConfigLoader(configDirPath);
-
-//   const config = await loader.load({
-//     name: 'config',
-//     schema: schemas.bot.config,
-//     secret: false,
-//   });
-//   const keys = await loader.load({ name: 'keys', schema: schemas.bot.keys, secret: true });
-
-//   const rest = new REST();
-//   rest.setToken(keys.botAuth);
-//   const api = new API(rest);
-
-//   return { config, keys, api, loader };
-// }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -7,12 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": [
-      "**",
-      "!**/package.json",
-      "!**/CHANGELOG.md",
-      "!apps/bot/src/bot/util/registry/commands.generated.ts"
-    ]
+    "includes": ["**", "!**/package.json", "!**/CHANGELOG.md"]
   },
   "formatter": {
     "enabled": true,

--- a/config/commands.json
+++ b/config/commands.json
@@ -510,6 +510,12 @@
     "name": "update-roles"
   },
   {
+    "default_member_permissions": "8",
+    "type": 1,
+    "contexts": [0],
+    "name": "leaderboard"
+  },
+  {
     "default_member_permissions": "6",
     "type": 1,
     "deployment": "LOCAL_ONLY",

--- a/packages/database/migrations/shard/002-leaderboard.up.sql
+++ b/packages/database/migrations/shard/002-leaderboard.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `guild` ADD COLUMN `leaderboardWebhook` varchar(200) DEFAULT NULL AFTER `resetHour`;

--- a/packages/database/schemas/full/shard.sql
+++ b/packages/database/schemas/full/shard.sql
@@ -76,6 +76,7 @@ CREATE TABLE `guild` (
   `lastTokenBurnDate` bigint(20) NOT NULL DEFAULT '0',
   `resetDay` tinyint(4) NOT NULL DEFAULT '0',
   `resetHour` tinyint(4) NOT NULL DEFAULT '0',
+  `leaderboardWebhook` varchar(200) DEFAULT NULL,
   `joinedAtDate` bigint(20) NOT NULL DEFAULT '0',
   `leftAtDate` bigint(20) NOT NULL DEFAULT '0',
   `addDate` bigint(20) NOT NULL DEFAULT '0',

--- a/packages/database/schemas/shard.md
+++ b/packages/database/schemas/shard.md
@@ -75,6 +75,7 @@ This document describes deprecations, requirements, and other notes for tables i
 |                  `lastCommandDate` | bigint(20)    |    ×     | 0          |
 |                         `resetDay` | tinyint(4)    |    ×     | 0          |
 |                        `resetHour` | tinyint(4)    |    ×     | 0          |
+|               `leaderboardWebhook` | varchar(200)  |    ☑︎    | NULL       |
 |                     `joinedAtDate` | bigint(20)    |    ×     | 0          |
 |                       `leftAtDate` | bigint(20)    |    ×     | 0          |
 |                          `addDate` | bigint(20)    |    ×     | 0          |

--- a/packages/database/schemas/stripped/shard.sql
+++ b/packages/database/schemas/stripped/shard.sql
@@ -75,6 +75,7 @@ CREATE TABLE `guild` (
   `lastTokenBurnDate` bigint(20) NOT NULL DEFAULT '0',
   `resetDay` tinyint(4) NOT NULL DEFAULT '0',
   `resetHour` tinyint(4) NOT NULL DEFAULT '0',
+  `leaderboardWebhook` varchar(200) DEFAULT NULL,
   `joinedAtDate` bigint(20) NOT NULL DEFAULT '0',
   `leftAtDate` bigint(20) NOT NULL DEFAULT '0',
   `addDate` bigint(20) NOT NULL DEFAULT '0',

--- a/packages/database/src/typings/shard.ts
+++ b/packages/database/src/typings/shard.ts
@@ -61,6 +61,7 @@ export interface GuildSchema {
   lastTokenBurnDate: Generated<string>; // bigint
   resetDay: Generated<number>;
   resetHour: Generated<number>;
+  leaderboardWebhook: string | null;
   joinedAtDate: Generated<string>; // bigint
   leftAtDate: Generated<string>; // bigint
   addDate: Generated<string>;


### PR DESCRIPTION
Ask for Premium messages now mention the Discord native Shop feature as the preferred way to create server subscriptions.

## Examples

<details>
<summary>"Ask For Premium" - periodic reminders</summary>

### Old
<img width="1252" height="598" alt="Screenshot_2025-08-18_at_10 07 11_PM" src="https://github.com/user-attachments/assets/791d1e7b-dc21-4531-b7bf-fcc4afd3c243" />

### New
<img width="1246" height="734" alt="Screenshot_2025-08-18_at_10 09 23_PM" src="https://github.com/user-attachments/assets/05fb1bb5-9155-414c-ae11-3ab9d8ef5e44" />

</details>

<details>
<summary>Cooldown Messages</summary>

### Old
<img width="619" height="173" alt="Screenshot 2025-08-21 at 3 01 28 PM" src="https://github.com/user-attachments/assets/04e99c0d-dd99-4c21-a987-1cc53b47024c" />

### New
<img width="613" height="237" alt="Screenshot 2025-08-21 at 3 01 35 PM" src="https://github.com/user-attachments/assets/5ecf617c-b92e-4c23-8901-8976ffb48127" />

_Cooldown messages are now ephemeral, to balance the larger size._
</details> 